### PR TITLE
Consistently format GUIDs in info

### DIFF
--- a/ffsengine.cpp
+++ b/ffsengine.cpp
@@ -1317,7 +1317,7 @@ UINT8 FfsEngine::parseSection(const QByteArray & section, QModelIndex & index, c
 
         // Get info
         name = guidToQString(guidDefinedSectionHeader->SectionDefinitionGuid);
-        info = tr("Section GUID: %1h\nType: %2h\nFull size: %3h (%4)\nHeader size: %5h (%6)\nBody size: %7h (%8)\nData offset: %9h\nAttributes: %10h")
+        info = tr("Section GUID: %1\nType: %2h\nFull size: %3h (%4)\nHeader size: %5h (%6)\nBody size: %7h (%8)\nData offset: %9h\nAttributes: %10h")
             .arg(name)
             .hexarg2(sectionHeader->Type, 2)
             .hexarg(section.size()).arg(section.size())


### PR DESCRIPTION
This is the only place where GUIDs are output with an 'h' at the end.