### PR TITLE
Support FFSv3 sections for both parsing and reconstructing.

### DIFF
--- a/ffs.cpp
+++ b/ffs.cpp
@@ -155,10 +155,10 @@ UINT32 sizeOfSectionHeader(const EFI_COMMON_SECTION_HEADER* header)
     if (!header)
         return 0;
 
-    const bool extended = false;
-    /*if (uint24ToUint32(header->Size) == EFI_SECTION2_IS_USED) {
+    bool extended = false;
+    if (uint24ToUint32(header->Size) == EFI_SECTION2_IS_USED) {
         extended = true;
-    }*/
+    }
 
     switch (header->Type)
     {


### PR DESCRIPTION
This is necessary to support editing the larger firmwares on modern mainboards.