### PR TITLE
Offset base by the preceding pad file

### DIFF
--- a/ffsengine.cpp
+++ b/ffsengine.cpp
@@ -3921,7 +3921,15 @@ UINT8 FfsEngine::reconstructSection(const QModelIndex& index, const UINT32 base,
             }*/
 
             if (base) {
-                result = rebase(reconstructed, base - teFixup + header.size());
+                UINT16 padding = 0;
+                const QModelIndex &padFileIndex = index.parent().sibling(index.parent().row() - 1, index.parent().column());
+                if (padFileIndex.isValid()) {
+                    if (model->subtype(padFileIndex) == EFI_FV_FILETYPE_PAD) {
+                        padding = model->header(padFileIndex).size() + model->body(padFileIndex).size();
+                    }
+                }
+
+                result = rebase(reconstructed, base - teFixup + header.size() + padding);
                 if (result) {
                     msg(tr("reconstructSection: executable section rebase failed"), index);
                     return result;


### PR DESCRIPTION
BIOS: [Supermicro A1Sri](http://www.supermicro.com/products/motherboard/atom/x10/a1sri-2758f.cfm)

In this BIOS, pad files are inserted to align the PE32 section in PEI files. The image base in the PE header includes this, but the computed base does not currently. As a result, rebuilding any PEI module with padding will compute a negative delta (very large in unsigned) and perform a bunch of invalid relocations even though nothing has changed.

This pull request checks the preceding file, and if it is a pad file, increments the base used for rebasing by the size of the pad file.

This may be fine on its own; I don't know enough about how other BIOSes use pad files to say for sure.