### PR TITLE
Added EFI_SIMPLE_POINTER_PROTOCOL patch for APTIO IV on Z87

### DIFF
--- a/UEFIPatch/patches.txt
+++ b/UEFIPatch/patches.txt
@@ -57,3 +57,11 @@ F7731B4C-58A2-4DF4-8980-5645D39ECE58 10 P:0FBA6C24380F:0FBA7424380F
 
 # CpuInitPei | Skylake-X
 01359D99-9446-456D-ADA4-50A711C03ADA 12 P:BE0080000023CE0B:BE0000000023CE0B 
+
+#----------------------------------------------------------------------------------
+# Broken EFI_SIMPLE_POINTER_PROTOCOL implementation patches
+# Fixes incorrect pointer position update/click condition on Z87 chips
+#----------------------------------------------------------------------------------
+
+# UHCD | ASUS Z87-Pro
+580DD900-385D-11D7-883A-00500473D4EB 10 P:807A3200745C807A4000:807A32007506807A4000 


### PR DESCRIPTION
I kind of completely forgot about it, and submit it only now, but perhaps some people will still find it useful. The added patch fixes EFI_SIMPLE_POINTER_PROTOCOL GetState implementation in certain APTIO IV implementations, where the pointer does not move (click) unless you hold a button at the same time you move the mouse.

The implementation looks like this, and the patch simply replaces OR by AND. 

```C
EFI_STATUS SimplePointerGetState(EFI_SIMPLE_POINTER_PROTOCOL *Protocol, EFI_SIMPLE_POINTER_STATE *State)
{
  if ( !State )
    return EFI_INVALID_PARAMETER;
  if ( gUsbData->MouseData[0] == -1 )
    return EFI_NOT_READY;
  MouseGetRelativeData(gUsbData->MouseData);
  TranslateUsbKey(gUsbData->MouseData);
  // The condition here is obviously wrong, was meant to be "nothing happened" not "both not happened"
  if ( !gMouseData->AmiMouse.State.PosChanged || !gMouseData->AmiMouse.ButtonChanged )
    return EFI_NOT_READY;
  gBS->CopyMem(State, &gMouseData->PosX, sizeof(EFI_SIMPLE_POINTER_STATE));
  gMouseData->PosX = 0;
  gMouseData->PosY = 0;
  gMouseData->PosZ = 0;
  gMouseData->AmiMouse.State.PosChanged = FALSE;
  gMouseData->AmiMouse.ButtonChanged = FALSE;
  return EFI_SUCCESS;
}
```

An example of the faulty firmware could be found here: https://www.asus.com/ru/Motherboards/Z87PROV_EDITION/HelpDesk_BIOS/
From what I know only the latest APTIO IV implementations are affected, so almost all Z87 and probably some Z97.

Just in case you may find it useful, here is the header for reverse-engineered AMI proprietary mouse pointer protocol (https://github.com/vit9696/AptioFixPkg/blob/master/Platform/AptioInputFix/AmiPointer.h). From what I know it still exists on APTIO V.