### PR TITLE
Enable building UEFITool as a library (QT Project Template += lib)

### DIFF
--- a/uefitool.pro
+++ b/uefitool.pro
@@ -2,7 +2,7 @@ QT       += core gui
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
 TARGET    = UEFITool
-TEMPLATE  = app
+TEMPLATE  = app lib
 
 SOURCES  += uefitool_main.cpp \
  uefitool.cpp \


### PR DESCRIPTION
This allows to build UEFITool as a shared library, Useful if you want to link against it.