### PR TITLE
Added ability to dump files found with search

### DIFF
--- a/UEFITool/ffsfinder.cpp
+++ b/UEFITool/ffsfinder.cpp
@@ -57,6 +57,11 @@ USTATUS FfsFinder::findHexPattern(const UModelIndex & index, const UByteArray & 
             // For patterns that cross header|body boundary, skip patterns entirely located in body, since
             // children search above has already found them.
             if (!(hasChildren && mode == SEARCH_MODE_ALL && offset/2 >= model->header(index).size())) {
+                UModelIndex savedIndex = index;
+                if (model->type(savedIndex) == Types::Section)
+                    savedIndex = index.parent();
+                if (model->type(savedIndex) == Types::File)
+                    addFoundFile(savedIndex);
                 msg(UString("Hex pattern \"") + UString(hexPattern)
                     + UString("\" found as \"") + hexBody.mid(offset, hexPattern.length()).toUpper()
                     + UString("\" in ") + model->name(model->parent(index))
@@ -126,6 +131,11 @@ USTATUS FfsFinder::findGuidPattern(const UModelIndex & index, const UByteArray &
     INT32 offset = regexp.indexIn(hexBody);
     while (offset >= 0) {
         if (offset % 2 == 0) {
+            UModelIndex savedIndex = index;
+            if (model->type(savedIndex) == Types::Section)
+                savedIndex = index.parent();
+            if (model->type(savedIndex) == Types::File)
+                addFoundFile(savedIndex);
             msg(UString("GUID pattern \"") + UString(guidPattern)
                 + UString("\" found as \"") + hexBody.mid(offset, hexPattern.length()).toUpper()
                 + UString("\" in ") + model->name(model->parent(index))
@@ -175,15 +185,10 @@ USTATUS FfsFinder::findTextPattern(const UModelIndex & index, const UString & pa
     int offset = -1;
     while ((offset = data.indexOf(pattern, offset + 1, caseSensitive)) >= 0) {
         UModelIndex savedIndex = index;
-
-        if (model->type(savedIndex) == Types::ItemTypes::Section)
+        if (model->type(savedIndex) == Types::Section)
             savedIndex = index.parent();
-
-        if (model->type(savedIndex) == Types::ItemTypes::File)
-        {
-            addObj(savedIndex);
-        }
-
+        if (model->type(savedIndex) == Types::File)
+            addFoundFile(savedIndex);
         msg((unicode ? UString("Unicode") : UString("ASCII")) + UString(" text \"") + UString(pattern)
             + UString("\" in ") + model->name(model->parent(index))
             + UString("/") + model->name(index)

--- a/UEFITool/ffsfinder.cpp
+++ b/UEFITool/ffsfinder.cpp
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 */
 
 #include "ffsfinder.h"
+#include "../common/types.h"
 
 USTATUS FfsFinder::findHexPattern(const UModelIndex & index, const UByteArray & hexPattern, const UINT8 mode)
 {
@@ -173,6 +174,15 @@ USTATUS FfsFinder::findTextPattern(const UModelIndex & index, const UString & pa
 
     int offset = -1;
     while ((offset = data.indexOf(pattern, offset + 1, caseSensitive)) >= 0) {
+        UModelIndex savedIndex = index;
+
+        if (model->type(savedIndex) == Types::ItemTypes::Section)
+            savedIndex = index.parent();
+
+        if (model->type(savedIndex) == Types::ItemTypes::File)
+        {
+            addObj(savedIndex);
+        }
 
         msg((unicode ? UString("Unicode") : UString("ASCII")) + UString(" text \"") + UString(pattern)
             + UString("\" in ") + model->name(model->parent(index))

--- a/UEFITool/ffsfinder.h
+++ b/UEFITool/ffsfinder.h
@@ -29,8 +29,8 @@ public:
     ~FfsFinder() {}
 
     std::vector<std::pair<UString, UModelIndex> > getMessages() const { return messagesVector; }
-    std::vector<UModelIndex> getFoundFiles() const { return foundObjects; }
-    void clearFoundFiles() { foundObjects.clear(); }
+    std::vector<UModelIndex> getFoundFiles() const { return foundFiles; }
+    void clearFoundFiles() { foundFiles.clear(); }
     void clearMessages() { messagesVector.clear(); }
 
     USTATUS findHexPattern(const UModelIndex & index, const UByteArray & hexPattern, const UINT8 mode);
@@ -44,11 +44,11 @@ public:
 private:
     const TreeModel* model;
     std::vector<std::pair<UString, UModelIndex> > messagesVector;
-    std::vector<UModelIndex> foundObjects;
+    std::vector<UModelIndex> foundFiles;
 
-    void addObj(const UModelIndex &index) {
-        if(std::find(foundObjects.begin(), foundObjects.end(), index) == foundObjects.end()) {
-            foundObjects.push_back(index);
+    void addFoundFile(const UModelIndex &index) {
+        if(std::find(foundFiles.begin(), foundFiles.end(), index) == foundFiles.end()) {
+            foundFiles.push_back(index);
         }
     }
 };

--- a/UEFITool/ffsfinder.h
+++ b/UEFITool/ffsfinder.h
@@ -29,18 +29,27 @@ public:
     ~FfsFinder() {}
 
     std::vector<std::pair<UString, UModelIndex> > getMessages() const { return messagesVector; }
+    std::vector<UModelIndex> getFoundFiles() const { return foundObjects; }
+    void clearFoundFiles() { foundObjects.clear(); }
     void clearMessages() { messagesVector.clear(); }
 
     USTATUS findHexPattern(const UModelIndex & index, const UByteArray & hexPattern, const UINT8 mode);
     USTATUS findGuidPattern(const UModelIndex & index, const UByteArray & guidPattern, const UINT8 mode);
     USTATUS findTextPattern(const UModelIndex & index, const UString & pattern, const UINT8 mode, const bool unicode, const Qt::CaseSensitivity caseSensitive);
 
+    void msg(const UString & message, const UModelIndex &index = UModelIndex()) {
+        messagesVector.push_back(std::pair<UString, UModelIndex>(message, index));
+    }
+
 private:
     const TreeModel* model;
     std::vector<std::pair<UString, UModelIndex> > messagesVector;
+    std::vector<UModelIndex> foundObjects;
 
-    void msg(const UString & message, const UModelIndex &index = UModelIndex()) {
-        messagesVector.push_back(std::pair<UString, UModelIndex>(message, index));
+    void addObj(const UModelIndex &index) {
+        if(std::find(foundObjects.begin(), foundObjects.end(), index) == foundObjects.end()) {
+            foundObjects.push_back(index);
+        }
     }
 };
 

--- a/UEFITool/searchdialog.ui
+++ b/UEFITool/searchdialog.ui
@@ -220,13 +220,6 @@
             </property>
            </widget>
           </item>
-          <item>
-           <widget class="QCheckBox" name="textDumpFilesCheckBox">
-            <property name="text">
-             <string>Dump files?</string>
-            </property>
-           </widget>
-          </item>
          </layout>
         </widget>
        </item>
@@ -263,7 +256,6 @@
   <tabstop>textEdit</tabstop>
   <tabstop>textUnicodeCheckBox</tabstop>
   <tabstop>textCaseSensitiveCheckBox</tabstop>
-  <tabstop>textDumpFilesCheckBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/UEFITool/searchdialog.ui
+++ b/UEFITool/searchdialog.ui
@@ -220,6 +220,13 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="textDumpFilesCheckBox">
+            <property name="text">
+             <string>Dump files?</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -256,6 +263,7 @@
   <tabstop>textEdit</tabstop>
   <tabstop>textUnicodeCheckBox</tabstop>
   <tabstop>textCaseSensitiveCheckBox</tabstop>
+  <tabstop>textDumpFilesCheckBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/UEFITool/uefitool.cpp
+++ b/UEFITool/uefitool.cpp
@@ -41,6 +41,8 @@ markingEnabled(true)
     connect(ui->actionOpenImageFileInNewWindow, SIGNAL(triggered()), this, SLOT(openImageFileInNewWindow()));
     connect(ui->actionSaveImageFile, SIGNAL(triggered()), this, SLOT(saveImageFile()));
     connect(ui->actionSearch, SIGNAL(triggered()), this, SLOT(search()));
+    connect(ui->actionExtractSearch, SIGNAL(triggered()), this, SLOT(extractSearchAsIs()));
+    connect(ui->actionExtractSearchBody, SIGNAL(triggered()), this, SLOT(extractSearchBody()));
     connect(ui->actionHexView, SIGNAL(triggered()), this, SLOT(hexView()));
     connect(ui->actionBodyHexView, SIGNAL(triggered()), this, SLOT(bodyHexView()));
     connect(ui->actionExtract, SIGNAL(triggered()), this, SLOT(extractAsIs()));
@@ -234,6 +236,8 @@ void UEFITool::populateUi(const QModelIndex &current)
     ui->actionExtract->setDisabled(model->hasEmptyHeader(current) && model->hasEmptyBody(current) && model->hasEmptyTail(current));
     ui->actionGoToData->setEnabled(type == Types::NvarEntry && subtype == Subtypes::LinkNvarEntry);
 
+
+
     // Disable rebuild for now
     //ui->actionRebuild->setDisabled(type == Types::Region && subtype == Subtypes::DescriptorRegion);
     //ui->actionReplace->setDisabled(type == Types::Region && subtype == Subtypes::DescriptorRegion);
@@ -265,6 +269,7 @@ void UEFITool::search()
     if (searchDialog->exec() != QDialog::Accepted)
         return;
 
+    ffsFinder->clearFoundFiles();
     QModelIndex rootIndex = model->index(0, 0);
 
     int index = searchDialog->ui->tabWidget->currentIndex();
@@ -313,10 +318,10 @@ void UEFITool::search()
             mode = SEARCH_MODE_ALL;
         ffsFinder->findTextPattern(rootIndex, pattern, mode, searchDialog->ui->textUnicodeCheckBox->isChecked(),
             (Qt::CaseSensitivity) searchDialog->ui->textCaseSensitiveCheckBox->isChecked());
-        if (searchDialog->ui->textDumpFilesCheckBox->isChecked())
-            saveFoundObjects();
         showFinderMessages();
     }
+
+    ui->menuExtractSearchActions->setEnabled(ffsFinder->getFoundFiles().size() > 0);
 }
 
 void UEFITool::hexView()
@@ -801,13 +806,22 @@ void UEFITool::showParserMessages()
     ui->parserMessagesListWidget->scrollToBottom();
 }
 
-void UEFITool::saveFoundObjects()
+void UEFITool::extractSearchAsIs()
+{
+    extractSearch(EXTRACT_MODE_AS_IS);
+}
+
+void UEFITool::extractSearchBody()
+{
+    extractSearch(EXTRACT_MODE_BODY);
+}
+
+void UEFITool::extractSearch(const UINT8 mode)
 {
     if (!ffsParser)
         return;
 
     std::vector<QModelIndex> foundFiles = ffsFinder->getFoundFiles();
-    ffsFinder->clearFoundFiles();
 
     if (foundFiles.size() == 0)
         return;
@@ -815,40 +829,39 @@ void UEFITool::saveFoundObjects()
     QString dir = QFileDialog::getExistingDirectory(this, tr("Select directory to save found files"), currentDir);
 
     if (dir.isEmpty()) {
-        ffsFinder->msg("You need to select a directory to extract found files");
+        ui->statusBar->showMessage("You need to select a directory to extract found files");
         return;
     }
 
-    for(const QModelIndex &index : foundFiles) 
-    {
-        if (!index.isValid())
-            continue;
+    QModelIndex index;
+    foreach (index, foundFiles) {
+        if (index.isValid()) {
+            QString name;
+            QByteArray extracted;
 
-        QString name;
-        QByteArray extracted;
+            USTATUS result = ffsOps->extract(index, name, extracted, mode);
 
-        USTATUS result = ffsOps->extract(index, name, extracted, EXTRACT_MODE_AS_IS);
+            if (result) 
+            {
+                ffsFinder->msg("Could not extract file \"" + model->name(index) + "\"", index);
+                continue;
+            }
 
-        if (result) 
-        {
-            ffsFinder->msg("Could not extract file \"" + model->name(index) + "\"", index);
-            continue;
+            QFile outputFile(dir + QDir::toNativeSeparators(QDir::separator() + name) + ".ffs");
+
+            if (!outputFile.open(QFile::WriteOnly)) 
+            {
+                ffsFinder->msg("Could not open output file \"" + name + "\" for writing", index);
+                continue;
+            }
+
+            outputFile.resize(0);
+            outputFile.write(extracted);
+            outputFile.close();
         }
-
-        QFile outputFile(dir + QDir::toNativeSeparators(QDir::separator() + name) + ".ffs");
-
-        if (!outputFile.open(QFile::WriteOnly)) 
-        {
-            ffsFinder->msg("Could not open output file \"" + name + "\" for writing", index);
-            continue;
-        }
-
-        outputFile.resize(0);
-        outputFile.write(extracted);
-        outputFile.close();
-
-        ffsFinder->msg("Sucessfully extracted \"" + name + "\"", index);
     }
+
+    showFinderMessages();
 }
 
 void UEFITool::showFinderMessages()

--- a/UEFITool/uefitool.cpp
+++ b/UEFITool/uefitool.cpp
@@ -313,6 +313,8 @@ void UEFITool::search()
             mode = SEARCH_MODE_ALL;
         ffsFinder->findTextPattern(rootIndex, pattern, mode, searchDialog->ui->textUnicodeCheckBox->isChecked(),
             (Qt::CaseSensitivity) searchDialog->ui->textCaseSensitiveCheckBox->isChecked());
+        if (searchDialog->ui->textDumpFilesCheckBox->isChecked())
+            saveFoundObjects();
         showFinderMessages();
     }
 }
@@ -797,6 +799,56 @@ void UEFITool::showParserMessages()
 
     ui->messagesTabWidget->setCurrentIndex(TAB_PARSER);
     ui->parserMessagesListWidget->scrollToBottom();
+}
+
+void UEFITool::saveFoundObjects()
+{
+    if (!ffsParser)
+        return;
+
+    std::vector<QModelIndex> foundFiles = ffsFinder->getFoundFiles();
+    ffsFinder->clearFoundFiles();
+
+    if (foundFiles.size() == 0)
+        return;
+
+    QString dir = QFileDialog::getExistingDirectory(this, tr("Select directory to save found files"), currentDir);
+
+    if (dir.isEmpty()) {
+        ffsFinder->msg("You need to select a directory to extract found files");
+        return;
+    }
+
+    for(const QModelIndex &index : foundFiles) 
+    {
+        if (!index.isValid())
+            continue;
+
+        QString name;
+        QByteArray extracted;
+
+        USTATUS result = ffsOps->extract(index, name, extracted, EXTRACT_MODE_AS_IS);
+
+        if (result) 
+        {
+            ffsFinder->msg("Could not extract file \"" + model->name(index) + "\"", index);
+            continue;
+        }
+
+        QFile outputFile(dir + QDir::toNativeSeparators(QDir::separator() + name) + ".ffs");
+
+        if (!outputFile.open(QFile::WriteOnly)) 
+        {
+            ffsFinder->msg("Could not open output file \"" + name + "\" for writing", index);
+            continue;
+        }
+
+        outputFile.resize(0);
+        outputFile.write(extracted);
+        outputFile.close();
+
+        ffsFinder->msg("Sucessfully extracted \"" + name + "\"", index);
+    }
 }
 
 void UEFITool::showFinderMessages()

--- a/UEFITool/uefitool.h
+++ b/UEFITool/uefitool.h
@@ -85,6 +85,10 @@ private slots:
     void bodyHexView();
     void goToData();
 
+    void extractSearch(const UINT8 mode);
+    void extractSearchAsIs();
+    void extractSearchBody();
+
     void extract(const UINT8 mode);
     void extractAsIs();
     void extractBody();
@@ -156,7 +160,6 @@ private:
     void showFitTable();
     void showSecurityInfo();
     void showBuilderMessages();
-    void saveFoundObjects();
 
     enum {
         TAB_PARSER,

--- a/UEFITool/uefitool.h
+++ b/UEFITool/uefitool.h
@@ -156,6 +156,7 @@ private:
     void showFitTable();
     void showSecurityInfo();
     void showBuilderMessages();
+    void saveFoundObjects();
 
     enum {
         TAB_PARSER,

--- a/UEFITool/uefitool.ui
+++ b/UEFITool/uefitool.ui
@@ -342,6 +342,16 @@
     <property name="title">
      <string>&amp;Action</string>
     </property>
+    <widget class="QMenu" name="menuExtractSearchActions">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="title">
+      <string>Found files</string>
+     </property>
+     <addaction name="actionExtractSearch"/>
+     <addaction name="actionExtractSearchBody"/>
+    </widget>
     <widget class="QMenu" name="menuCapsuleActions">
      <property name="enabled">
       <bool>false</bool>
@@ -531,6 +541,7 @@
     <addaction name="menuVolumeActions"/>
     <addaction name="menuFileActions"/>
     <addaction name="menuSectionActions"/>
+    <addaction name="menuExtractSearchActions"/>
     <addaction name="separator"/>
     <addaction name="menuStoreActions"/>
     <addaction name="menuEntryActions"/>
@@ -605,9 +616,6 @@
    </property>
   </action>
   <action name="actionExtractBody">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
    <property name="text">
     <string>Extract &amp;body...</string>
    </property>
@@ -616,6 +624,22 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+E</string>
+   </property>
+  </action>
+  <action name="actionExtractSearch">
+   <property name="toolTip">
+    <string>Extract found files as they are</string>
+   </property>
+   <property name="text">
+    <string>E&amp;xtract as is...</string>
+   </property>
+  </action>
+  <action name="actionExtractSearchBody">
+   <property name="toolTip">
+    <string>Extract body of found files</string>
+   </property>
+   <property name="text">
+    <string>Extract &amp;body...</string>
    </property>
   </action>
   <action name="actionRemove">


### PR DESCRIPTION
This might be a useful addition. I was really annoyed I couldn't simply dump all the files which are returned with a text search so I implemented it. Pretty ad-hoc implementation but it does what it's supposed to.

I only tried this on GNU/Linux but I see no reason why it shouldn't be working on Windows. At the moment I don't have access to a Windows machine so I cannot test it but I will build and test this on Windows once I get home (next week probably).

If you think this functionality improves UEFITool but you want changes to the code feel free to tell me and I'll adjust the PR accordingly.

Greetings

PS. There is an explanation with screenshots availabe at my fork. Have a look [here](https://github.com/s3rb31/UEFITool/blob/new_engine-mod/README.md).