### PR TITLE
Refactoring round 1

### DIFF
--- a/UEFITool/ffsfinder.cpp
+++ b/UEFITool/ffsfinder.cpp
@@ -35,12 +35,7 @@ USTATUS FfsFinder::findHexPattern(const UModelIndex & index, const UByteArray & 
 
     bool hasChildren = (model->rowCount(index) > 0);
     for (int i = 0; i < model->rowCount(index); i++) {
-#if ((QT_VERSION_MAJOR == 5) && (QT_VERSION_MINOR < 6)) || (QT_VERSION_MAJOR < 5)
-        findHexPattern(index.child(i, index.column()), hexPattern, mode);
-#else
         findHexPattern(index.model()->index(i, index.column(), index), hexPattern, mode);
-#endif
-
     }
 
     UByteArray data;
@@ -109,11 +104,7 @@ USTATUS FfsFinder::findGuidPattern(const UModelIndex & index, const UByteArray &
 
     bool hasChildren = (model->rowCount(index) > 0);
     for (int i = 0; i < model->rowCount(index); i++) {
-#if ((QT_VERSION_MAJOR == 5) && (QT_VERSION_MINOR < 6)) || (QT_VERSION_MAJOR < 5)
-        findGuidPattern(index.child(i, index.column()), guidPattern, mode);
-#else
         findGuidPattern(index.model()->index(i, index.column(), index), guidPattern, mode);
-#endif
     }
 
     UByteArray data;
@@ -197,11 +188,7 @@ USTATUS FfsFinder::findTextPattern(const UModelIndex & index, const UString & pa
 
     bool hasChildren = (model->rowCount(index) > 0);
     for (int i = 0; i < model->rowCount(index); i++) {
-#if ((QT_VERSION_MAJOR == 5) && (QT_VERSION_MINOR < 6)) || (QT_VERSION_MAJOR < 5)
-        findTextPattern(index.child(i, index.column()), pattern, mode, unicode, caseSensitive);
-#else
         findTextPattern(index.model()->index(i, index.column(), index), pattern, mode, unicode, caseSensitive);
-#endif
     }
 
     UByteArray body;

--- a/UEFITool/hexviewdialog.cpp
+++ b/UEFITool/hexviewdialog.cpp
@@ -37,18 +37,32 @@ void HexViewDialog::setFont(const QFont &font)
     hexView->setFont(font);
 }
 
-void HexViewDialog::setItem(const UModelIndex & index, bool bodyOnly)
+void HexViewDialog::setItem(const UModelIndex & index, HexViewType type)
 {
     const TreeModel * model = (const TreeModel*)index.model();
-    
-    // Set dialog title
     UString itemName = model->name(index);
     UString itemText = model->text(index);
-    setWindowTitle(UString("Hex view: ") + (itemText.isEmpty() ? itemName : itemName + " | " + itemText));
     
-    // Set hex data
+    // Set hex data and dialog title
     QByteArray hexdata;
-    if (bodyOnly) hexdata = model->body(index);
-    else hexdata = model->header(index) + model->body(index) + model->tail(index);
+    UString dialogTitle;
+    
+    switch (type) {
+        case fullHexView:
+            dialogTitle = UString("Hex view: ");
+            hexdata = model->header(index) + model->body(index) + model->tail(index);
+            break;
+        case bodyHexView:
+            dialogTitle = UString("Body hex view: ");
+            hexdata = model->body(index);
+            break;
+        case uncompressedHexView:
+            dialogTitle = UString("Uncompressed hex view: ");
+            hexdata = model->uncompressedData(index);
+            break;
+    }
+    
+    dialogTitle += itemText.isEmpty() ? itemName : itemName + " | " + itemText;
+    setWindowTitle(dialogTitle);
     hexView->setData(hexdata);
 }

--- a/UEFITool/hexviewdialog.h
+++ b/UEFITool/hexviewdialog.h
@@ -24,13 +24,19 @@ class HexViewDialog : public QDialog
     Q_OBJECT
 
 public:
+    enum HexViewType {
+        fullHexView,
+        bodyHexView,
+        uncompressedHexView
+    };
+    
     HexViewDialog(QWidget *parent = 0);
     ~HexViewDialog();
     Ui::HexViewDialog* ui;
 
-    void setItem(const UModelIndex & index, bool bodyOnly);
+    void setItem(const UModelIndex & index, HexViewType dataType);
     void setFont(const QFont &font);
-
+    
 private:
     QHexEdit * hexView;
 };

--- a/UEFITool/uefitool.h
+++ b/UEFITool/uefitool.h
@@ -83,6 +83,7 @@ private slots:
 
     void hexView();
     void bodyHexView();
+    void uncompressedHexView();
     void goToData();
 
     void extract(const UINT8 mode);
@@ -143,8 +144,6 @@ private:
     QFont currentFont;
     const QString version;
     bool markingEnabled;
-
-    bool enableExtractBodyUncompressed(const QModelIndex &current);
 
     bool eventFilter(QObject* obj, QEvent* event);
     void dragEnterEvent(QDragEnterEvent* event);

--- a/UEFITool/uefitool.pro
+++ b/UEFITool/uefitool.pro
@@ -1,5 +1,4 @@
-QT += core gui
-greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+QT += core gui widgets
 
 TARGET = UEFITool
 TEMPLATE = app

--- a/UEFITool/uefitool.ui
+++ b/UEFITool/uefitool.ui
@@ -351,6 +351,7 @@
      </property>
      <addaction name="actionHexView"/>
      <addaction name="actionBodyHexView"/>
+     <addaction name="actionUncompressedHexView"/>
      <addaction name="separator"/>
      <addaction name="actionExtract"/>
      <addaction name="actionExtractBody"/>
@@ -401,6 +402,7 @@
      </property>
      <addaction name="actionHexView"/>
      <addaction name="actionBodyHexView"/>
+     <addaction name="actionUncompressedHexView"/>
      <addaction name="separator"/>
      <addaction name="actionExtract"/>
      <addaction name="actionExtractBody"/>
@@ -421,6 +423,7 @@
      </property>
      <addaction name="actionHexView"/>
      <addaction name="actionBodyHexView"/>
+     <addaction name="actionUncompressedHexView"/>
      <addaction name="separator"/>
      <addaction name="actionExtract"/>
      <addaction name="actionExtractBody"/>
@@ -445,6 +448,7 @@
      </property>
      <addaction name="actionHexView"/>
      <addaction name="actionBodyHexView"/>
+     <addaction name="actionUncompressedHexView"/>
      <addaction name="separator"/>
      <addaction name="actionExtract"/>
      <addaction name="actionExtractBody"/>
@@ -482,6 +486,7 @@
      </property>
      <addaction name="actionHexView"/>
      <addaction name="actionBodyHexView"/>
+     <addaction name="actionUncompressedHexView"/>
      <addaction name="separator"/>
      <addaction name="actionGoToData"/>
      <addaction name="separator"/>
@@ -507,6 +512,7 @@
      </property>
      <addaction name="actionHexView"/>
      <addaction name="actionBodyHexView"/>
+     <addaction name="actionUncompressedHexView"/>
      <addaction name="separator"/>
      <addaction name="actionExtract"/>
      <addaction name="actionExtractBody"/>
@@ -843,6 +849,17 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+D</string>
+   </property>
+  </action>
+  <action name="actionUncompressedHexView">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Un&amp;compressed hex view...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Alt+D</string>
    </property>
   </action>
   <action name="actionLoadGuidDatabase">

--- a/common/ffs.h
+++ b/common/ffs.h
@@ -414,9 +414,6 @@ typedef struct EFI_COMMON_SECTION_HEADER_APPLE {
 // Section2 usage indicator
 #define EFI_SECTION2_IS_USED 0xFFFFFF
 
-// Apple section usage indicator
-#define EFI_SECTION_APPLE_USED 0x7FFF
-
 // File section types
 #define EFI_SECTION_ALL 0x00 // Impossible attribute for file in the FS
 

--- a/common/ffsbuilder.cpp
+++ b/common/ffsbuilder.cpp
@@ -92,12 +92,7 @@ USTATUS FfsBuilder::buildCapsule(const UModelIndex & index, UByteArray & capsule
             }
 
             // Build image
-#if ((QT_VERSION_MAJOR == 5) && (QT_VERSION_MINOR < 6)) || (QT_VERSION_MAJOR < 5)
-            UModelIndex imageIndex = index.child(0, 0);
-#else
             UModelIndex imageIndex = index.model()->index(0, 0, index);
-#endif
-
             UByteArray imageData;
             
             // Check image type
@@ -170,19 +165,11 @@ USTATUS FfsBuilder::buildIntelImage(const UModelIndex & index, UByteArray & inte
     // Rebuild
     else if (model->action(index) == Actions::Rebuild) {
         // First child will always be descriptor for this type of image, and it's read only for now
-#if ((QT_VERSION_MAJOR == 5) && (QT_VERSION_MINOR < 6)) || (QT_VERSION_MAJOR < 5)
-        intelImage = model->header(index.child(0, 0)) + model->body(index.child(0, 0)) + model->tail(index.child(0, 0));
-#else
         intelImage = model->header(index.model()->index(0, 0, index)) + model->body(index.model()->index(0, 0, index)) + model->tail(index.model()->index(0, 0, index));
-#endif
 
         // Process other regions
         for (int i = 1; i < model->rowCount(index); i++) {
-#if ((QT_VERSION_MAJOR == 5) && (QT_VERSION_MINOR < 6)) || (QT_VERSION_MAJOR < 5)
-            UModelIndex currentRegion = index.child(i, 0);
-#else
             UModelIndex currentRegion = index.model()->index(i, 0, index);
-#endif
 
             // Skip regions with Remove action
             if (model->action(currentRegion) == Actions::Remove)
@@ -282,14 +269,9 @@ USTATUS FfsBuilder::buildRawArea(const UModelIndex & index, UByteArray & rawArea
             // Build children
             for (int i = 0; i < model->rowCount(index); i++) {
                 USTATUS result = U_SUCCESS;
-
-#if ((QT_VERSION_MAJOR == 5) && (QT_VERSION_MINOR < 6)) || (QT_VERSION_MAJOR < 5)
-                UModelIndex currentChild = index.child(i, 0);
-#else
                 UModelIndex currentChild = index.model()->index(i, 0, index);
-#endif
-
                 UByteArray currentData;
+                
                 // Check child type
                 if (model->type(currentChild) == Types::Volume) {
                     result = buildVolume(currentChild, currentData);

--- a/common/ffsops.cpp
+++ b/common/ffsops.cpp
@@ -39,24 +39,9 @@ USTATUS FfsOperations::extract(const UModelIndex & index, UString & name, UByteA
         extracted += model->body(index);
     }
     else if (mode == EXTRACT_MODE_BODY_UNCOMPRESSED) {
-        name += UString("_body_unc");
-        // Extract without header and tail, uncompressed
+        name += UString("_body_uncompressed");
         extracted.clear();
-        // There is no need to redo decompression, we can use child items
-        for (int i = 0; i < model->rowCount(index); i++) {
-#if ((QT_VERSION_MAJOR == 5) && (QT_VERSION_MINOR < 6)) || (QT_VERSION_MAJOR < 5)
-            UModelIndex childIndex = index.child(i, 0);
-#else
-            UModelIndex childIndex = index.model()->index(i, 0, index);
-#endif
-            
-            // Ensure 4-byte alignment of current section
-             extracted += UByteArray(ALIGN4((UINT32)extracted.size()) - (UINT32)extracted.size(), '\x00');
-             // Add current section header, body and tail
-             extracted += model->header(childIndex);
-             extracted += model->body(childIndex);
-             extracted += model->tail(childIndex);
-        }
+        extracted += model->uncompressedData(index);
     }
     else
         return U_UNKNOWN_EXTRACT_MODE;

--- a/common/ffsreport.cpp
+++ b/common/ffsreport.cpp
@@ -69,11 +69,7 @@ USTATUS FfsReport::generateRecursive(std::vector<UString> & report, const UModel
 
     // Information on child items
     for (int i = 0; i < model->rowCount(index); i++) {
-#if ((QT_VERSION_MAJOR == 5) && (QT_VERSION_MINOR < 6)) || (QT_VERSION_MAJOR < 5)
-        generateRecursive(report, index.child(i,0), level + 1);
-#else
         generateRecursive(report, index.model()->index(i,0,index), level + 1);
-#endif
     }
 
     return U_SUCCESS;

--- a/common/ffsutils.cpp
+++ b/common/ffsutils.cpp
@@ -40,12 +40,7 @@ USTATUS findFileRecursive(TreeModel *model, const UModelIndex index, const UStri
 
     bool hasChildren = (model->rowCount(index) > 0);
     for (int i = 0; i < model->rowCount(index); i++) {
-#if ((QT_VERSION_MAJOR == 5) && (QT_VERSION_MINOR < 6)) || (QT_VERSION_MAJOR < 5)
-        findFileRecursive(model, index.child(i, index.column()), hexPattern, mode, files);
-#else
         findFileRecursive(model, index.model()->index(i, index.column(), index), hexPattern, mode, files);
-#endif
-
     }
 
     UByteArray data;

--- a/common/guiddatabase.cpp
+++ b/common/guiddatabase.cpp
@@ -116,11 +116,7 @@ GuidDatabase guidDatabaseFromTreeRecursive(TreeModel * model, const UModelIndex 
         return db;
 
     for (int i = 0; i < model->rowCount(index); i++) {
-#if ((QT_VERSION_MAJOR == 5) && (QT_VERSION_MINOR < 6)) || (QT_VERSION_MAJOR < 5)
-        GuidDatabase tmpDb = guidDatabaseFromTreeRecursive(model, index.child(i, index.column()));
-#else
         GuidDatabase tmpDb = guidDatabaseFromTreeRecursive(model, index.model()->index(i, index.column(), index));
-#endif
 
         db.insert(tmpDb.begin(), tmpDb.end());
     }

--- a/common/nvramparser.cpp
+++ b/common/nvramparser.cpp
@@ -226,11 +226,7 @@ USTATUS NvramParser::parseNvarStore(const UModelIndex & index)
             // Search previously added entries for a link to this variable
             // WARNING: O(n^2), may be very slow
             for (int i = model->rowCount(index) - 1; i >= 0; i--) {
-#if ((QT_VERSION_MAJOR == 5) && (QT_VERSION_MINOR < 6)) || (QT_VERSION_MAJOR < 5)
-                nvarIndex = index.child(i, 0);
-#else
                 nvarIndex = index.model()->index(i, 0, index);
-#endif
 
                 if (model->hasEmptyParsingData(nvarIndex) == false) {
                     UByteArray nvarData = model->parsingData(nvarIndex);
@@ -503,11 +499,7 @@ USTATUS NvramParser::parseNvramVolumeBody(const UModelIndex & index)
 
     // Parse bodies
     for (int i = 0; i < model->rowCount(index); i++) {
-#if ((QT_VERSION_MAJOR == 5) && (QT_VERSION_MINOR < 6)) || (QT_VERSION_MAJOR < 5)
-        UModelIndex current = index.child(i, 0);
-#else
         UModelIndex current = index.model()->index(i, 0, index);
-#endif
 
         switch (model->type(current)) {
         case Types::FdcStore:
@@ -1828,11 +1820,7 @@ USTATUS NvramParser::parseEvsaStoreBody(const UModelIndex & index)
 
     // Reparse all data variables to detect invalid ones and assign name and test to valid ones
     for (int i = 0; i < model->rowCount(index); i++) {
-#if ((QT_VERSION_MAJOR == 5) && (QT_VERSION_MINOR < 6)) || (QT_VERSION_MAJOR < 5)
-        UModelIndex current = index.child(i, 0);
-#else
         UModelIndex current = index.model()->index(i, 0, index);
-#endif
 
         if (model->subtype(current) == Subtypes::DataEvsaEntry) {
             UByteArray header = model->header(current);

--- a/common/parsingdata.h
+++ b/common/parsingdata.h
@@ -30,6 +30,7 @@ typedef struct VOLUME_PARSING_DATA_ {
     BOOLEAN  hasExtendedHeader;
     BOOLEAN  hasAppleCrc32;
     BOOLEAN  isWeakAligned;
+    BOOLEAN  requiresSectionAlignmentQuirk;
 } VOLUME_PARSING_DATA;
 
 typedef struct FILE_PARSING_DATA_ {

--- a/common/treeitem.h
+++ b/common/treeitem.h
@@ -86,6 +86,10 @@ public:
     bool hasEmptyParsingData() const { return itemParsingData.isEmpty(); }
     void setParsingData(const UByteArray & pdata) { itemParsingData = pdata; }
 
+    UByteArray uncompressedData() const { return itemUncompressedData; };
+    bool hasEmptyUncompressedData() const { return itemUncompressedData.isEmpty(); }
+    void setUncompressedData(const UByteArray & ucdata) { itemUncompressedData = ucdata; }
+    
     UINT8 marking() const { return itemMarking; }
     void setMarking(const UINT8 marking) { itemMarking = marking; }
 
@@ -105,6 +109,7 @@ private:
     bool       itemFixed;
     bool       itemCompressed;
     UByteArray itemParsingData;
+    UByteArray itemUncompressedData;
     TreeItem*  parentItem;
 };
 

--- a/common/treemodel.cpp
+++ b/common/treemodel.cpp
@@ -460,6 +460,34 @@ void TreeModel::setParsingData(const UModelIndex &index, const UByteArray &data)
     emit dataChanged(this->index(0, 0), index);
 }
 
+UByteArray TreeModel::uncompressedData(const UModelIndex &index) const
+{
+    if (!index.isValid())
+        return UByteArray();
+
+    TreeItem *item = static_cast<TreeItem*>(index.internalPointer());
+    return item->uncompressedData();
+}
+
+bool TreeModel::hasEmptyUncompressedData(const UModelIndex &index) const
+{
+    if (!index.isValid())
+        return true;
+
+    TreeItem *item = static_cast<TreeItem*>(index.internalPointer());
+    return item->hasEmptyUncompressedData();
+}
+
+void TreeModel::setUncompressedData(const UModelIndex &index, const UByteArray &data)
+{
+    if (!index.isValid())
+        return;
+
+    TreeItem *item = static_cast<TreeItem*>(index.internalPointer());
+    item->setUncompressedData(data);
+    emit dataChanged(this->index(0, 0), index);
+}
+
 UModelIndex TreeModel::addItem(const UINT32 offset, const UINT8 type, const UINT8 subtype,
     const UString & name, const UString & text, const UString & info,
     const UByteArray & header, const UByteArray & body, const UByteArray & tail,
@@ -559,11 +587,7 @@ UModelIndex TreeModel::findByBase(UINT32 base) const
 goDeeper:
     int n = rowCount(parentIndex);
     for (int i = 0; i < n; i++) {
-#if ((QT_VERSION_MAJOR == 5) && (QT_VERSION_MINOR < 6)) || (QT_VERSION_MAJOR < 5)
-        UModelIndex currentIndex = parentIndex.child(i, 0);
-#else
         UModelIndex currentIndex = parentIndex.model()->index(i, 0, parentIndex);
-#endif
     
         UINT32 currentBase = this->base(currentIndex);
         UINT32 fullSize = (UINT32)(header(currentIndex).size() + body(currentIndex).size() + tail(currentIndex).size());

--- a/common/treemodel.h
+++ b/common/treemodel.h
@@ -169,7 +169,11 @@ public:
 
     bool compressed(const UModelIndex &index) const;
     void setCompressed(const UModelIndex &index, const bool compressed);
-
+    
+    UByteArray uncompressedData(const UModelIndex &index) const;
+    bool hasEmptyUncompressedData(const UModelIndex &index) const;
+    void setUncompressedData(const UModelIndex &index, const UByteArray &ucdata);
+    
     UINT8 marking(const UModelIndex &index) const;
     void setMarking(const UModelIndex &index, const UINT8 marking);
 

--- a/common/ustring.cpp
+++ b/common/ustring.cpp
@@ -20,11 +20,7 @@ UString usprintf(const char* fmt, ...)
     va_list vl;
     va_start(vl, fmt);
 
-#if ((QT_VERSION_MAJOR == 5) && (QT_VERSION_MINOR < 6)) || (QT_VERSION_MAJOR < 5)
-    msg.vsprintf(fmt, vl);
-#else
     msg = msg.vasprintf(fmt, vl);
-#endif
 
     va_end(vl);
     return msg;


### PR DESCRIPTION
- introduce Extract Uncompressed and Uncompressed Hex View actions for compressed items, fixes #150 
- add a check and description for section alignment quirk (compiled out for now), will help fixing #178 later
- remove unused code to support Qt 5.5 and earlier Qt versions
- remove unused section parsing code