### PR TITLE
Add support for Intel ME FPT header version 2.1

### DIFF
--- a/common/descriptor.cpp
+++ b/common/descriptor.cpp
@@ -107,6 +107,9 @@ UString jedecIdToUString(UINT8 vendorId, UINT8 deviceId0, UINT8 deviceId1)
     case 0x204013: return UString("Micron M45PE40");
     case 0x204014: return UString("Micron M45PE80");
     case 0x204015: return UString("Micron M45PE16");
+    case 0x204017: return UString("Micron XM25QH64C");
+    case 0x204018: return UString("Micron XM25QH128C");
+    case 0x204019: return UString("Micron XM25QH256C");
     case 0x207114: return UString("Micron M25PX80");
     case 0x207115: return UString("Micron M25PX16");
     case 0x207116: return UString("Micron M25PX32");

--- a/common/ffs.cpp
+++ b/common/ffs.cpp
@@ -162,7 +162,7 @@ UString bpdtEntryTypeToUString(const UINT16 type)
         case BPDT_ENTRY_TYPE_IFP_OVERRIDE:       return UString("IFP Override");
         case BPDT_ENTRY_TYPE_DEBUG_TOKENS:       return UString("Debug Tokens");
         case BPDT_ENTRY_TYPE_USF_PHY_CONFIG:     return UString("USF Phy Config");
-        case BPDT_ENTRY_TYPE_USB_GPP_LUN_ID:     return UString("USF GPP LUN ID");
+        case BPDT_ENTRY_TYPE_USF_GPP_LUN_ID:     return UString("USF GPP LUN ID");
         case BPDT_ENTRY_TYPE_PMC:                return UString("PMC");
         case BPDT_ENTRY_TYPE_IUNIT:              return UString("iUnit");
         case BPDT_ENTRY_TYPE_NVM_CONFIG:         return UString("NVM Config");
@@ -175,6 +175,8 @@ UString bpdtEntryTypeToUString(const UINT16 type)
         case BPDT_ENTRY_TYPE_TCSS_FW_IOM:        return UString("TCSS FW IOM");
         case BPDT_ENTRY_TYPE_TCSS_FW_PHY:        return UString("TCSS FW PHY");
         case BPDT_ENTRY_TYPE_TBT:                return UString("TCSS TBT");
+        case BPDT_ENTRY_TYPE_USB_PHY:            return UString("USB PHY");
+        case BPDT_ENTRY_TYPE_PCHC:               return UString("PCHC");
         case BPDT_ENTRY_TYPE_SAMF:               return UString("SAMF");
         case BPDT_ENTRY_TYPE_PPHY:               return UString("PPHY");
         default:                                 return usprintf("Unknown %u", type);

--- a/common/ffs.h
+++ b/common/ffs.h
@@ -635,7 +635,7 @@ typedef struct BPDT_ENTRY_ {
 #define BPDT_ENTRY_TYPE_IFP_OVERRIDE     10
 #define BPDT_ENTRY_TYPE_DEBUG_TOKENS     11
 #define BPDT_ENTRY_TYPE_USF_PHY_CONFIG   12
-#define BPDT_ENTRY_TYPE_USB_GPP_LUN_ID   13
+#define BPDT_ENTRY_TYPE_USF_GPP_LUN_ID   13
 #define BPDT_ENTRY_TYPE_PMC              14
 #define BPDT_ENTRY_TYPE_IUNIT            15
 #define BPDT_ENTRY_TYPE_NVM_CONFIG       16
@@ -648,6 +648,8 @@ typedef struct BPDT_ENTRY_ {
 #define BPDT_ENTRY_TYPE_TCSS_FW_IOM      23
 #define BPDT_ENTRY_TYPE_TCSS_FW_PHY      24
 #define BPDT_ENTRY_TYPE_TBT              25
+#define BPDT_ENTRY_TYPE_USB_PHY          31
+#define BPDT_ENTRY_TYPE_PCHC             32
 #define BPDT_ENTRY_TYPE_SAMF             41
 #define BPDT_ENTRY_TYPE_PPHY             42
 

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -4648,6 +4648,8 @@ make_partition_table_consistent:
 
             // TODO: make this generic again
             if (partitions[i].ptEntry.Type > BPDT_ENTRY_TYPE_TBT
+                && partitions[i].ptEntry.Type != BPDT_ENTRY_TYPE_USB_PHY
+                && partitions[i].ptEntry.Type != BPDT_ENTRY_TYPE_PCHC
                 && partitions[i].ptEntry.Type != BPDT_ENTRY_TYPE_SAMF
                 && partitions[i].ptEntry.Type != BPDT_ENTRY_TYPE_PPHY) {
                 msg(usprintf("%s: BPDT entry of unknown type found", __FUNCTION__), partitionIndex);

--- a/common/me.h
+++ b/common/me.h
@@ -34,22 +34,42 @@ const UByteArray ME_VERSION_SIGNATURE2("\x24\x4D\x4E\x32", 4); //$MN2
 #define ME_ROM_BYPASS_VECTOR_SIZE 0x10
 const UByteArray FPT_HEADER_SIGNATURE("\x24\x46\x50\x54", 4); //$FPT
 
+// Header version 1.0 or 2.0, default
 typedef struct FPT_HEADER_ {
     UINT32 Signature;
     UINT32 NumEntries;
-    UINT8  HeaderVersion;
+    UINT8  HeaderVersion;  // 0x10 or 0x20
     UINT8  EntryVersion;
     UINT8  HeaderLength;
-    UINT8  Checksum;      // One bit for Redundant before IFWI
-    UINT16 TicksToAdd;
-    UINT16 TokensToAdd;
-    UINT32 UmaSize;       // Flags in SPS
-    UINT32 FlashLayout;   // Crc32 before IFWI
+    UINT8  HeaderChecksum; // One bit for Redundant
+    UINT16 FlashCycleLife; // Maybe also TicksToAdd
+    UINT16 FlashCycleLimit;// Maybe also TokensToAdd
+    UINT32 UmaSize;        // Maybe also Flags
+    UINT32 Flags;          // Maybe also FlashLayout
     UINT16 FitcMajor;
     UINT16 FitcMinor;
     UINT16 FitcHotfix;
     UINT16 FitcBuild;
 } FPT_HEADER;
+
+// Header version 2.1, special case
+#define FPT_HEADER_VERSION_21 0x21
+typedef struct FPT_HEADER_21_ {
+    UINT32 Signature;
+    UINT32 NumEntries;
+    UINT8  HeaderVersion;  // 0x21
+    UINT8  EntryVersion;
+    UINT8  HeaderLength;
+    UINT8  Flags;          // One bit for Redundant
+    UINT16 TicksToAdd;
+    UINT16 TokensToAdd;
+    UINT32 SPSFlags;
+    UINT32 HeaderCrc32;    // Header + Entries sums to 0
+    UINT16 FitcMajor;
+    UINT16 FitcMinor;
+    UINT16 FitcHotfix;
+    UINT16 FitcBuild;
+} FPT_HEADER_21;
 
 typedef struct FPT_HEADER_ENTRY_{
     CHAR8  Name[4];


### PR DESCRIPTION
Also adds some missing JEDEC IDs for XMC flash chips (a fully-owned Chinese branch of Micron)
<img width="832" alt="XMC" src="https://user-images.githubusercontent.com/1845688/186595945-7897aec1-4faa-45b4-a677-8bebcd3a69b3.png">

Also fixes some minor warnings from ME parser by adding missing BPDT entry types