### PR TITLE
Add Meson buildsystem

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,18 @@ jobs:
           tag: ${{ github.ref }}
           file_glob: true
 
+  build_linux_meson:
+    name: Build on Linux with Meson
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Deps
+        run: sudo apt-get install -qq zlib1g-dev meson qt5-default
+      - name: Configure build
+        run: mkdir build-meson && meson ./build-meson
+      - name: Build everything
+        run: ninja -C build-meson
+
   build_win:
     name: Build on Windows
     runs-on: windows-2019

--- a/UEFIExtract/meson.build
+++ b/UEFIExtract/meson.build
@@ -1,0 +1,18 @@
+executable(
+  'UEFIExtract',
+  sources: [
+    'uefiextract_main.cpp',
+    'ffsdumper.cpp',
+    'uefidump.cpp',
+  ],
+  link_with: [
+    lzma,
+    bstrlib,
+    uefitoolcommon,
+  ],
+  dependencies: [
+    zlib,
+  ],
+  install: true,
+  install_dir: get_option('bindir')
+)

--- a/common/meson.build
+++ b/common/meson.build
@@ -1,0 +1,41 @@
+lzma = static_library('lzma',
+  sources: [
+    'LZMA/LzmaDecompress.c',
+    'LZMA/SDK/C/Bra86.c',
+    'LZMA/SDK/C/LzmaDec.c',
+    'Tiano/EfiTianoDecompress.c',
+  ],
+)
+
+bstrlib = static_library('bstrlib',
+  sources: [
+    'bstrlib/bstrlib.c',
+    'bstrlib/bstrwrap.cpp',
+  ],
+)
+
+uefitoolcommon = static_library('uefitoolcommon',
+  sources: [
+    'guiddatabase.cpp',
+    'types.cpp',
+    'descriptor.cpp',
+    'ffs.cpp',
+    'nvram.cpp',
+    'nvramparser.cpp',
+    'meparser.cpp',
+    'ffsparser.cpp',
+    'ffsreport.cpp',
+    'peimage.cpp',
+    'treeitem.cpp',
+    'treemodel.cpp',
+    'utility.cpp',
+    'ustring.cpp',
+    'sha256.c',
+  ],
+  c_args: [
+    '-DU_ENABLE_NVRAM_PARSING_SUPPORT',
+    '-DU_ENABLE_ME_PARSING_SUPPORT',
+    '-DU_ENABLE_FIT_PARSING_SUPPORT',
+    '-DU_ENABLE_GUID_DATABASE_SUPPORT',
+  ],
+)

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,11 @@
+project('UEFITool', ['c', 'cpp'],
+  version: 'A60',
+  license: 'BSD-2-Clause',
+  meson_version: '>=0.53.2',
+  default_options : ['c_std=c11', 'cpp_std=c++11'],
+)
+
+zlib = dependency('zlib')
+
+subdir('common')
+subdir('UEFIExtract')


### PR DESCRIPTION
This allows UEFIExtract to build on a greater variety of targets and more
importantly allows us to build with the system-defined hardening protections
present in enterprise distributions.