### PR TITLE
Update appstream metadata to fix screenshot URL

### DIFF
--- a/appstream/appdata.xml
+++ b/appstream/appdata.xml
@@ -9,7 +9,7 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://github.com/LongSoft/UEFITool/blob/new_engine/appstream/UEFITool.png?raw=true</image>
+      <image type="source">https://github.com/LongSoft/UEFITool/raw/new_engine/appstream/UEFITool.png</image>
     </screenshot>
   </screenshots>
   <releases>


### PR DESCRIPTION
For some reason flathub doesn't like the GitHub blob URL, switch to the raw URL so the screenshot can be loaded. 

Note: there's no need to delete older release entries in the metadata, and the new entry should be included in the release instead, so a tagged tarball is all we need and we won't need to pull this xml separately anymore. https://github.com/flathub/com.github.LongSoft.UEFITool/pull/5