### PR TITLE
Apply hex cleaning to search dialog paste operations

### DIFF
--- a/UEFITool/CMakeLists.txt
+++ b/UEFITool/CMakeLists.txt
@@ -32,7 +32,7 @@ SET(PROJECT_SOURCES
  uefitool.cpp
  searchdialog.cpp
  hexviewdialog.cpp
- guidlineedit.cpp
+ hexlineedit.cpp
  ffsfinder.cpp
  hexspinbox.cpp
  qhexedit2/qhexedit.cpp

--- a/UEFITool/hexlineedit.h
+++ b/UEFITool/hexlineedit.h
@@ -1,4 +1,4 @@
-/* guidlineedit.h
+/* hexlineedit.h
 
   Copyright (c) 2014, Nikolaj Schlej. All rights reserved.
   This program and the accompanying materials
@@ -11,9 +11,11 @@
 
   */
 
-#ifndef GUIDLINEEDIT_H
-#define GUIDLINEEDIT_H
+#ifndef HEXLINEEDIT_H
+#define HEXLINEEDIT_H
 
+#include <QApplication>
+#include <QClipboard>
 #include <QLineEdit>
 #include <QKeyEvent>
 #include <QKeySequence>
@@ -21,16 +23,29 @@
 
 #include "../common/basetypes.h"
 
-class GuidLineEdit : public QLineEdit
+class HexLineEdit : public QLineEdit
 {
+     Q_OBJECT
+     Q_PROPERTY(bool editAsGuid READ editAsGuid WRITE setEditAsGuid)
+
 public:
-    GuidLineEdit(QWidget * parent = 0);
-    GuidLineEdit(const QString & contents, QWidget * parent = 0);
-    ~GuidLineEdit();
+    HexLineEdit(QWidget * parent = 0);
+    HexLineEdit(const QString & contents, QWidget * parent = 0);
+    ~HexLineEdit();
+
+    void setEditAsGuid(bool editAsGuid)
+    {
+        m_editAsGuid = editAsGuid;
+    }
+    bool editAsGuid() const
+    { return m_editAsGuid; }
+
+private:
+    bool m_editAsGuid;
 
 protected:
     void keyPressEvent(QKeyEvent * event);
 
 };
 
-#endif // GUIDLINEEDIT_H
+#endif // HEXLINEEDIT_H

--- a/UEFITool/searchdialog.ui
+++ b/UEFITool/searchdialog.ui
@@ -35,7 +35,10 @@
         </widget>
        </item>
        <item row="0" column="1">
-        <widget class="QLineEdit" name="hexEdit">
+        <widget class="HexLineEdit" name="hexEdit">
+         <property name="editAsGuid">
+          <bool>false</bool>
+         </property>
          <property name="inputMask">
           <string/>
          </property>
@@ -89,7 +92,10 @@
         </widget>
        </item>
        <item row="0" column="1">
-        <widget class="GuidLineEdit" name="guidEdit">
+        <widget class="HexLineEdit" name="guidEdit">
+         <property name="editAsGuid">
+          <bool>true</bool>
+         </property>
          <property name="inputMask">
           <string>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</string>
          </property>
@@ -241,9 +247,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>GuidLineEdit</class>
+   <class>HexLineEdit</class>
    <extends>QLineEdit</extends>
-   <header>guidlineedit.h</header>
+   <header>hexlineedit.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/UEFITool/uefitool.pro
+++ b/UEFITool/uefitool.pro
@@ -15,7 +15,7 @@ HEADERS += uefitool.h \
  hexviewdialog.h \
  gotobasedialog.h \
  gotoaddressdialog.h \
- guidlineedit.h \
+ hexlineedit.h \
  ffsfinder.h \
  hexspinbox.h \
  ../common/fitparser.h \
@@ -69,7 +69,7 @@ SOURCES += uefitool_main.cpp \
  uefitool.cpp \
  searchdialog.cpp \
  hexviewdialog.cpp \
- guidlineedit.cpp \
+ hexlineedit.cpp \
  ffsfinder.cpp \
  hexspinbox.cpp \
  ../common/fitparser.cpp \


### PR DESCRIPTION
EDK-II and other code is full of representations of GUIDs such as `{ 0xBB25CF6F, 0xF1D4, 0x11D2, { 0x9A, 0x0C, 0x00, 0x90, 0x27, 0x3F, 0xC1, 0xFD }}`.

It can be quite inconvenient to have to manually clean these into the format `BB25CF6FF1D411D29A0C0090273FC1FD` before pasting into UEFITool's GUID search function each time. This pull request does the required cleaning automatically, so you can copy all of something like the above and then paste it directly into the GUID field, getting the desired result, which I believe should be much more convenient in daily use.

Due to limitations on hooking paste in `QLineEdit`, we lose any non-plain text formatting of whatever was in the clipboard before this operation (which would not normally happen when pasting formatted text into a plain text application), but I believe this should not be a major issue.