### PR TITLE
Fix UINT32 underflow during NVRAM parsing (in NvramParser::parseEvsaStoreBody)

### DIFF
--- a/common/nvramparser.cpp
+++ b/common/nvramparser.cpp
@@ -1693,7 +1693,7 @@ USTATUS NvramParser::parseEvsaStoreBody(const UModelIndex & index)
         
         // Check entry size
         variableSize = sizeof(EVSA_ENTRY_HEADER);
-        if (unparsedSize < variableSize || unparsedSize < entryHeader->Size) {
+        if (unparsedSize < variableSize || unparsedSize < entryHeader->Size || entryHeader->Size < 2) {
             body = data.mid(offset);
             info = usprintf("Full size: %Xh (%u)", (UINT32)body.size(), (UINT32)body.size());
             


### PR DESCRIPTION
This PR fixes UINT32 underflow in `NvramParser::parseEvsaStoreBody`.
The issue occurs here: https://github.com/LongSoft/UEFITool/blob/5f134f783ad6d1e1cf58fc1133d40e64840b5950/common/nvramparser.cpp#L1716
`calculateChecksum8` function takes as its second parameter a `UINT32 bufferSize`.
Thus, if `entryHeader->Size` is 0 or 1, bufferSize will become `MAX_UINT32` or `(MAX_UINT32 - 1)`.

This will lead to OOB access inside `calculateChecksum8` and segfault:
```
./build/UEFIExtract/UEFIExtract ~/tmp/2aa828cf6eaa4d5f9b7e86722838c97f40409fff082832a71c764a56662b31c4.bin

[1]    67234 segmentation fault  ./build/UEFIExtract/UEFIExtract
```

To fix this, I added an additional check here: https://github.com/LongSoft/UEFITool/blob/5f134f783ad6d1e1cf58fc1133d40e64840b5950/common/nvramparser.cpp#L1696

Just in case, I am attaching several files that cause this problem.
[uefitool_crash.zip](https://github.com/LongSoft/UEFITool/files/10013894/uefitool_crash.zip)
