### PR TITLE
Fix FfsParser issues found by fuzzing (2)

### DIFF
--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -1135,6 +1135,9 @@ USTATUS FfsParser::parseVolumeHeader(const UByteArray & volume, const UINT32 loc
         msgInvalidChecksum = true;
     
     // Get info
+    if (headerSize >= volume.size()) {
+        return U_INVALID_VOLUME;
+    }
     UByteArray header = volume.left(headerSize);
     UByteArray body = volume.mid(headerSize);
     UString name = guidToUString(volumeHeader->FileSystemGuid);

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -4220,6 +4220,9 @@ USTATUS FfsParser::parseBpdtRegion(const UByteArray & region, const UINT32 local
     }
     
 make_partition_table_consistent:
+    if (partitions.empty()) {
+        return U_INVALID_ME_PARTITION_TABLE;
+    }
     // Sort partitions by offset
     std::sort(partitions.begin(), partitions.end());
     
@@ -4521,6 +4524,9 @@ USTATUS FfsParser::parseCpdRegion(const UByteArray & region, const UINT32 localO
     }
     
 make_partition_table_consistent:
+    if (partitions.empty()) {
+        return U_INVALID_ME_PARTITION_TABLE;
+    }
     // Sort partitions by offset
     std::sort(partitions.begin(), partitions.end());
     

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -1125,7 +1125,7 @@ USTATUS FfsParser::parseVolumeHeader(const UByteArray & volume, const UINT32 loc
     bool msgInvalidChecksum = false;
 
     if (volumeHeader->HeaderLength < sizeof(EFI_FIRMWARE_VOLUME_HEADER)) {
-        msg(usprintf("%s: input volume header length %Xh (%u) is smaller than volume header size", __FUNCTION__, (UINT32)volumeHeader->HeaderLength, (UINT32)volumeHeader->HeaderLength));
+        msg(usprintf("%s: input volume header length %04Xh (%hu) is smaller than volume header size", __FUNCTION__, volumeHeader->HeaderLength, volumeHeader->HeaderLength));
         return U_INVALID_VOLUME;
     }
     UByteArray tempHeader((const char*)volumeHeader, volumeHeader->HeaderLength);
@@ -1159,6 +1159,12 @@ USTATUS FfsParser::parseVolumeHeader(const UByteArray & volume, const UINT32 loc
     (msgInvalidChecksum ? usprintf(", invalid, should be %04Xh", calculated) : UString(", valid"));
     
     // Extended header present
+
+    // volumeHeader->ExtHeaderOffset should be aligned to 4 bytes
+    if (volumeHeader->ExtHeaderOffset % 4) {
+        msg(usprintf("%s: ExtHeaderOffset %04Xh (%hu) is not aligned by 4 bytes", __FUNCTION__, volumeHeader->ExtHeaderOffset, volumeHeader->ExtHeaderOffset));
+        return U_INVALID_VOLUME;
+    }
     if (volumeHeader->Revision > 1 && volumeHeader->ExtHeaderOffset) {
         if (volume.size() < volumeHeader->ExtHeaderOffset + sizeof(EFI_FIRMWARE_VOLUME_EXT_HEADER)) {
             return U_INVALID_VOLUME;

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -1123,6 +1123,11 @@ USTATUS FfsParser::parseVolumeHeader(const UByteArray & volume, const UINT32 loc
     
     // Check header checksum by recalculating it
     bool msgInvalidChecksum = false;
+
+    if (volumeHeader->HeaderLength < sizeof(EFI_FIRMWARE_VOLUME_HEADER)) {
+        msg(usprintf("%s: input volume header length %Xh (%u) is smaller than volume header size", __FUNCTION__, (UINT32)volumeHeader->HeaderLength, (UINT32)volumeHeader->HeaderLength));
+        return U_INVALID_VOLUME;
+    }
     UByteArray tempHeader((const char*)volumeHeader, volumeHeader->HeaderLength);
     ((EFI_FIRMWARE_VOLUME_HEADER*)tempHeader.data())->Checksum = 0;
     UINT16 calculated = calculateChecksum16((const UINT16*)tempHeader.constData(), volumeHeader->HeaderLength);

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -1160,6 +1160,9 @@ USTATUS FfsParser::parseVolumeHeader(const UByteArray & volume, const UINT32 loc
     
     // Extended header present
     if (volumeHeader->Revision > 1 && volumeHeader->ExtHeaderOffset) {
+        if (volume.size() < volumeHeader->ExtHeaderOffset + sizeof(EFI_FIRMWARE_VOLUME_EXT_HEADER)) {
+            return U_INVALID_VOLUME;
+        }
         const EFI_FIRMWARE_VOLUME_EXT_HEADER* extendedHeader = (const EFI_FIRMWARE_VOLUME_EXT_HEADER*)(volume.constData() + volumeHeader->ExtHeaderOffset);
         info += usprintf("\nExtended header size: %Xh (%u)\nVolume GUID: ",
                          extendedHeader->ExtHeaderSize, extendedHeader->ExtHeaderSize) + guidToUString(extendedHeader->FvName, false);

--- a/common/meparser.cpp
+++ b/common/meparser.cpp
@@ -223,7 +223,9 @@ USTATUS MeParser::parseFptRegion(const UByteArray & region, const UModelIndex & 
     }
     
 make_partition_table_consistent:
-
+    if (partitions.empty()) {
+        return U_INVALID_ME_PARTITION_TABLE;
+    }
     // Sort partitions by offset
     std::sort(partitions.begin(), partitions.end());
     
@@ -384,6 +386,9 @@ USTATUS MeParser::parseIfwi16Region(const UByteArray & region, const UModelIndex
     }
     
 make_partition_table_consistent:
+    if (partitions.empty()) {
+        return U_INVALID_ME_PARTITION_TABLE;
+    }
     // Sort partitions by offset
     std::sort(partitions.begin(), partitions.end());
     
@@ -565,6 +570,9 @@ USTATUS MeParser::parseIfwi17Region(const UByteArray & region, const UModelIndex
     }
     
 make_partition_table_consistent:
+    if (partitions.empty()) {
+        return U_INVALID_ME_PARTITION_TABLE;
+    }
     // Sort partitions by offset
     std::sort(partitions.begin(), partitions.end());
     

--- a/fuzzing/ffsparser_fuzzer.cpp
+++ b/fuzzing/ffsparser_fuzzer.cpp
@@ -27,5 +27,8 @@ extern "C" int LLVMFuzzerTestOneInput(const char *Data, long long Size) {
     // Parse the image
     (void)ffsParser->parse(UByteArray(Data, (uint32_t)Size));
 
+    delete model;
+    delete ffsParser;
+
     return 0;
 }


### PR DESCRIPTION
Hi @NikolajSchlej.
Using the fuzzer that was recently added, I caught all the crashes you originally tried to fix here https://github.com/LongSoft/UEFITool/commit/b8567d32cc158eb68d900d9a161e92889e643627 (and more).

After all these fixes, so far I have not been able to catch any more crashes with default configuration.
