### PR TITLE
add additional check for BPDT store size

### DIFF
--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -1403,8 +1403,10 @@ continue_searching: {}
             }
             
             // Check size candidate
-            if (sizeCandidate == 0)
+            if (sizeCandidate == 0 || sizeCandidate > restSize) {
+                msg(usprintf("%s: invalid BpdtStore size (sizeCandidate = 0x%x, restSize = 0x%x)", __FUNCTION__, sizeCandidate, restSize), index);
                 continue;
+            }
             
             // All checks passed, BPDT found
             nextItemType = Types::BpdtStore;


### PR DESCRIPTION
A situation may arise when `sizeCandidate` > `restSize`.
In that case message "one of objects inside overlaps the end of data..." will be printed and parsing routine will be interrupted (in `FfsParser::parseRawArea`).

Thus, some UEFI Firmware Volumes may be skipped.