### PR TITLE
Fix for AMI NVAR parser based on kaitai struct

### DIFF
--- a/common/generated/ami_nvar.cpp
+++ b/common/generated/ami_nvar.cpp
@@ -6,24 +6,18 @@
 ami_nvar_t::ami_nvar_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent, ami_nvar_t* p__root) : kaitai::kstruct(p__io) {
     m__parent = p__parent;
     m__root = this;
-    m_entries = 0;
-
-    try {
-        _read();
-    } catch(...) {
-        _clean_up();
-        throw;
-    }
+    m_entries = nullptr;
+    _read();
 }
 
 void ami_nvar_t::_read() {
-    m_entries = new std::vector<nvar_entry_t*>();
+    m_entries = std::unique_ptr<std::vector<std::unique_ptr<nvar_entry_t>>>(new std::vector<std::unique_ptr<nvar_entry_t>>());
     {
         int i = 0;
         nvar_entry_t* _;
         do {
             _ = new nvar_entry_t(m__io, this, m__root);
-            m_entries->push_back(_);
+            m_entries->push_back(std::move(std::unique_ptr<nvar_entry_t>(_)));
             i++;
         } while (!( ((_->signature_first() != 78) || (_io()->is_eof())) ));
     }
@@ -34,24 +28,12 @@ ami_nvar_t::~ami_nvar_t() {
 }
 
 void ami_nvar_t::_clean_up() {
-    if (m_entries) {
-        for (std::vector<nvar_entry_t*>::iterator it = m_entries->begin(); it != m_entries->end(); ++it) {
-            delete *it;
-        }
-        delete m_entries; m_entries = 0;
-    }
 }
 
 ami_nvar_t::nvar_attributes_t::nvar_attributes_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_t* p__parent, ami_nvar_t* p__root) : kaitai::kstruct(p__io) {
     m__parent = p__parent;
     m__root = p__root;
-
-    try {
-        _read();
-    } catch(...) {
-        _clean_up();
-        throw;
-    }
+    _read();
 }
 
 void ami_nvar_t::nvar_attributes_t::_read() {
@@ -75,18 +57,12 @@ void ami_nvar_t::nvar_attributes_t::_clean_up() {
 ami_nvar_t::ucs2_string_t::ucs2_string_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_body_t* p__parent, ami_nvar_t* p__root) : kaitai::kstruct(p__io) {
     m__parent = p__parent;
     m__root = p__root;
-    m_ucs2_chars = 0;
-
-    try {
-        _read();
-    } catch(...) {
-        _clean_up();
-        throw;
-    }
+    m_ucs2_chars = nullptr;
+    _read();
 }
 
 void ami_nvar_t::ucs2_string_t::_read() {
-    m_ucs2_chars = new std::vector<uint16_t>();
+    m_ucs2_chars = std::unique_ptr<std::vector<uint16_t>>(new std::vector<uint16_t>());
     {
         int i = 0;
         uint16_t _;
@@ -103,21 +79,12 @@ ami_nvar_t::ucs2_string_t::~ucs2_string_t() {
 }
 
 void ami_nvar_t::ucs2_string_t::_clean_up() {
-    if (m_ucs2_chars) {
-        delete m_ucs2_chars; m_ucs2_chars = 0;
-    }
 }
 
 ami_nvar_t::nvar_extended_attributes_t::nvar_extended_attributes_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_body_t* p__parent, ami_nvar_t* p__root) : kaitai::kstruct(p__io) {
     m__parent = p__parent;
     m__root = p__root;
-
-    try {
-        _read();
-    } catch(...) {
-        _clean_up();
-        throw;
-    }
+    _read();
 }
 
 void ami_nvar_t::nvar_extended_attributes_t::_read() {
@@ -138,18 +105,12 @@ void ami_nvar_t::nvar_extended_attributes_t::_clean_up() {
 ami_nvar_t::nvar_entry_t::nvar_entry_t(kaitai::kstream* p__io, ami_nvar_t* p__parent, ami_nvar_t* p__root) : kaitai::kstruct(p__io) {
     m__parent = p__parent;
     m__root = p__root;
-    m_attributes = 0;
-    m_body = 0;
-    m__io__raw_body = 0;
+    m_attributes = nullptr;
+    m_body = nullptr;
+    m__io__raw_body = nullptr;
     f_offset = false;
     f_end_offset = false;
-
-    try {
-        _read();
-    } catch(...) {
-        _clean_up();
-        throw;
-    }
+    _read();
 }
 
 void ami_nvar_t::nvar_entry_t::_read() {
@@ -187,14 +148,14 @@ void ami_nvar_t::nvar_entry_t::_read() {
     n_attributes = true;
     if (signature_first() == 78) {
         n_attributes = false;
-        m_attributes = new nvar_attributes_t(m__io, this, m__root);
+        m_attributes = std::unique_ptr<nvar_attributes_t>(new nvar_attributes_t(m__io, this, m__root));
     }
     n_body = true;
     if (signature_first() == 78) {
         n_body = false;
         m__raw_body = m__io->read_bytes((size() - ((4 + 2) + 4)));
-        m__io__raw_body = new kaitai::kstream(m__raw_body);
-        m_body = new nvar_entry_body_t(m__io__raw_body, this, m__root);
+        m__io__raw_body = std::unique_ptr<kaitai::kstream>(new kaitai::kstream(m__raw_body));
+        m_body = std::unique_ptr<nvar_entry_body_t>(new nvar_entry_body_t(m__io__raw_body.get(), this, m__root));
     }
     n_invoke_end_offset = true;
     if ( ((signature_first() == 78) && (end_offset() >= 0)) ) {
@@ -217,17 +178,8 @@ void ami_nvar_t::nvar_entry_t::_clean_up() {
     if (!n_next) {
     }
     if (!n_attributes) {
-        if (m_attributes) {
-            delete m_attributes; m_attributes = 0;
-        }
     }
     if (!n_body) {
-        if (m__io__raw_body) {
-            delete m__io__raw_body; m__io__raw_body = 0;
-        }
-        if (m_body) {
-            delete m_body; m_body = 0;
-        }
     }
     if (!n_invoke_end_offset) {
     }
@@ -252,8 +204,8 @@ int32_t ami_nvar_t::nvar_entry_t::end_offset() {
 ami_nvar_t::nvar_entry_body_t::nvar_entry_body_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_t* p__parent, ami_nvar_t* p__root) : kaitai::kstruct(p__io) {
     m__parent = p__parent;
     m__root = p__root;
-    m_ucs2_name = 0;
-    m_extended_header_attributes = 0;
+    m_ucs2_name = nullptr;
+    m_extended_header_attributes = nullptr;
     f_extended_header_attributes = false;
     f_data_start_offset = false;
     f_extended_header_size_field = false;
@@ -263,13 +215,7 @@ ami_nvar_t::nvar_entry_body_t::nvar_entry_body_t(kaitai::kstream* p__io, ami_nva
     f_data_end_offset = false;
     f_extended_header_size = false;
     f_extended_header_hash = false;
-
-    try {
-        _read();
-    } catch(...) {
-        _clean_up();
-        throw;
-    }
+    _read();
 }
 
 void ami_nvar_t::nvar_entry_body_t::_read() {
@@ -291,7 +237,7 @@ void ami_nvar_t::nvar_entry_body_t::_read() {
     n_ucs2_name = true;
     if ( ((!(_parent()->attributes()->ascii_name())) && (!(_parent()->attributes()->data_only())) && (_parent()->attributes()->valid())) ) {
         n_ucs2_name = false;
-        m_ucs2_name = new ucs2_string_t(m__io, this, m__root);
+        m_ucs2_name = std::unique_ptr<ucs2_string_t>(new ucs2_string_t(m__io, this, m__root));
     }
     n_invoke_data_start = true;
     if (data_start_offset() >= 0) {
@@ -313,16 +259,10 @@ void ami_nvar_t::nvar_entry_body_t::_clean_up() {
     if (!n_ascii_name) {
     }
     if (!n_ucs2_name) {
-        if (m_ucs2_name) {
-            delete m_ucs2_name; m_ucs2_name = 0;
-        }
     }
     if (!n_invoke_data_start) {
     }
     if (f_extended_header_attributes && !n_extended_header_attributes) {
-        if (m_extended_header_attributes) {
-            delete m_extended_header_attributes; m_extended_header_attributes = 0;
-        }
     }
     if (f_extended_header_size_field && !n_extended_header_size_field) {
     }
@@ -336,17 +276,17 @@ void ami_nvar_t::nvar_entry_body_t::_clean_up() {
 
 ami_nvar_t::nvar_extended_attributes_t* ami_nvar_t::nvar_entry_body_t::extended_header_attributes() {
     if (f_extended_header_attributes)
-        return m_extended_header_attributes;
+        return m_extended_header_attributes.get();
     n_extended_header_attributes = true;
     if ( ((_parent()->attributes()->valid()) && (_parent()->attributes()->extended_header()) && (extended_header_size() >= (1 + 2))) ) {
         n_extended_header_attributes = false;
         std::streampos _pos = m__io->pos();
         m__io->seek((_io()->pos() - extended_header_size()));
-        m_extended_header_attributes = new nvar_extended_attributes_t(m__io, this, m__root);
+        m_extended_header_attributes = std::unique_ptr<nvar_extended_attributes_t>(new nvar_extended_attributes_t(m__io, this, m__root));
         m__io->seek(_pos);
         f_extended_header_attributes = true;
     }
-    return m_extended_header_attributes;
+    return m_extended_header_attributes.get();
 }
 
 int32_t ami_nvar_t::nvar_entry_body_t::data_start_offset() {

--- a/common/generated/ami_nvar.cpp
+++ b/common/generated/ami_nvar.cpp
@@ -5,19 +5,25 @@
 
 ami_nvar_t::ami_nvar_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent, ami_nvar_t* p__root) : kaitai::kstruct(p__io) {
     m__parent = p__parent;
-    m__root = this; (void)p__root;
-    m_entries = nullptr;
-    _read();
+    m__root = this;
+    m_entries = 0;
+
+    try {
+        _read();
+    } catch(...) {
+        _clean_up();
+        throw;
+    }
 }
 
 void ami_nvar_t::_read() {
-    m_entries = std::unique_ptr<std::vector<std::unique_ptr<nvar_entry_t>>>(new std::vector<std::unique_ptr<nvar_entry_t>>());
+    m_entries = new std::vector<nvar_entry_t*>();
     {
         int i = 0;
         nvar_entry_t* _;
         do {
             _ = new nvar_entry_t(m__io, this, m__root);
-            m_entries->push_back(std::move(std::unique_ptr<nvar_entry_t>(_)));
+            m_entries->push_back(_);
             i++;
         } while (!( ((_->signature_first() != 78) || (_io()->is_eof())) ));
     }
@@ -28,12 +34,24 @@ ami_nvar_t::~ami_nvar_t() {
 }
 
 void ami_nvar_t::_clean_up() {
+    if (m_entries) {
+        for (std::vector<nvar_entry_t*>::iterator it = m_entries->begin(); it != m_entries->end(); ++it) {
+            delete *it;
+        }
+        delete m_entries; m_entries = 0;
+    }
 }
 
 ami_nvar_t::nvar_attributes_t::nvar_attributes_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_t* p__parent, ami_nvar_t* p__root) : kaitai::kstruct(p__io) {
     m__parent = p__parent;
     m__root = p__root;
-    _read();
+
+    try {
+        _read();
+    } catch(...) {
+        _clean_up();
+        throw;
+    }
 }
 
 void ami_nvar_t::nvar_attributes_t::_read() {
@@ -57,12 +75,18 @@ void ami_nvar_t::nvar_attributes_t::_clean_up() {
 ami_nvar_t::ucs2_string_t::ucs2_string_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_body_t* p__parent, ami_nvar_t* p__root) : kaitai::kstruct(p__io) {
     m__parent = p__parent;
     m__root = p__root;
-    m_ucs2_chars = nullptr;
-    _read();
+    m_ucs2_chars = 0;
+
+    try {
+        _read();
+    } catch(...) {
+        _clean_up();
+        throw;
+    }
 }
 
 void ami_nvar_t::ucs2_string_t::_read() {
-    m_ucs2_chars = std::unique_ptr<std::vector<uint16_t>>(new std::vector<uint16_t>());
+    m_ucs2_chars = new std::vector<uint16_t>();
     {
         int i = 0;
         uint16_t _;
@@ -79,12 +103,21 @@ ami_nvar_t::ucs2_string_t::~ucs2_string_t() {
 }
 
 void ami_nvar_t::ucs2_string_t::_clean_up() {
+    if (m_ucs2_chars) {
+        delete m_ucs2_chars; m_ucs2_chars = 0;
+    }
 }
 
 ami_nvar_t::nvar_extended_attributes_t::nvar_extended_attributes_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_body_t* p__parent, ami_nvar_t* p__root) : kaitai::kstruct(p__io) {
     m__parent = p__parent;
     m__root = p__root;
-    _read();
+
+    try {
+        _read();
+    } catch(...) {
+        _clean_up();
+        throw;
+    }
 }
 
 void ami_nvar_t::nvar_extended_attributes_t::_read() {
@@ -105,12 +138,18 @@ void ami_nvar_t::nvar_extended_attributes_t::_clean_up() {
 ami_nvar_t::nvar_entry_t::nvar_entry_t(kaitai::kstream* p__io, ami_nvar_t* p__parent, ami_nvar_t* p__root) : kaitai::kstruct(p__io) {
     m__parent = p__parent;
     m__root = p__root;
-    m_attributes = nullptr;
-    m_body = nullptr;
-    m__io__raw_body = nullptr;
+    m_attributes = 0;
+    m_body = 0;
+    m__io__raw_body = 0;
     f_offset = false;
     f_end_offset = false;
-    _read();
+
+    try {
+        _read();
+    } catch(...) {
+        _clean_up();
+        throw;
+    }
 }
 
 void ami_nvar_t::nvar_entry_t::_read() {
@@ -148,14 +187,14 @@ void ami_nvar_t::nvar_entry_t::_read() {
     n_attributes = true;
     if (signature_first() == 78) {
         n_attributes = false;
-        m_attributes = std::unique_ptr<nvar_attributes_t>(new nvar_attributes_t(m__io, this, m__root));
+        m_attributes = new nvar_attributes_t(m__io, this, m__root);
     }
     n_body = true;
     if (signature_first() == 78) {
         n_body = false;
         m__raw_body = m__io->read_bytes((size() - ((4 + 2) + 4)));
-        m__io__raw_body = std::unique_ptr<kaitai::kstream>(new kaitai::kstream(m__raw_body));
-        m_body = std::unique_ptr<nvar_entry_body_t>(new nvar_entry_body_t(m__io__raw_body.get(), this, m__root));
+        m__io__raw_body = new kaitai::kstream(m__raw_body);
+        m_body = new nvar_entry_body_t(m__io__raw_body, this, m__root);
     }
     n_invoke_end_offset = true;
     if ( ((signature_first() == 78) && (end_offset() >= 0)) ) {
@@ -178,8 +217,17 @@ void ami_nvar_t::nvar_entry_t::_clean_up() {
     if (!n_next) {
     }
     if (!n_attributes) {
+        if (m_attributes) {
+            delete m_attributes; m_attributes = 0;
+        }
     }
     if (!n_body) {
+        if (m__io__raw_body) {
+            delete m__io__raw_body; m__io__raw_body = 0;
+        }
+        if (m_body) {
+            delete m_body; m_body = 0;
+        }
     }
     if (!n_invoke_end_offset) {
     }
@@ -188,7 +236,7 @@ void ami_nvar_t::nvar_entry_t::_clean_up() {
 int32_t ami_nvar_t::nvar_entry_t::offset() {
     if (f_offset)
         return m_offset;
-    m_offset = (int32_t)_io()->pos();
+    m_offset = _io()->pos();
     f_offset = true;
     return m_offset;
 }
@@ -196,7 +244,7 @@ int32_t ami_nvar_t::nvar_entry_t::offset() {
 int32_t ami_nvar_t::nvar_entry_t::end_offset() {
     if (f_end_offset)
         return m_end_offset;
-    m_end_offset = (int32_t)_io()->pos();
+    m_end_offset = _io()->pos();
     f_end_offset = true;
     return m_end_offset;
 }
@@ -204,8 +252,8 @@ int32_t ami_nvar_t::nvar_entry_t::end_offset() {
 ami_nvar_t::nvar_entry_body_t::nvar_entry_body_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_t* p__parent, ami_nvar_t* p__root) : kaitai::kstruct(p__io) {
     m__parent = p__parent;
     m__root = p__root;
-    m_ucs2_name = nullptr;
-    m_extended_header_attributes = nullptr;
+    m_ucs2_name = 0;
+    m_extended_header_attributes = 0;
     f_extended_header_attributes = false;
     f_data_start_offset = false;
     f_extended_header_size_field = false;
@@ -215,7 +263,13 @@ ami_nvar_t::nvar_entry_body_t::nvar_entry_body_t(kaitai::kstream* p__io, ami_nva
     f_data_end_offset = false;
     f_extended_header_size = false;
     f_extended_header_hash = false;
-    _read();
+
+    try {
+        _read();
+    } catch(...) {
+        _clean_up();
+        throw;
+    }
 }
 
 void ami_nvar_t::nvar_entry_body_t::_read() {
@@ -237,7 +291,7 @@ void ami_nvar_t::nvar_entry_body_t::_read() {
     n_ucs2_name = true;
     if ( ((!(_parent()->attributes()->ascii_name())) && (!(_parent()->attributes()->data_only())) && (_parent()->attributes()->valid())) ) {
         n_ucs2_name = false;
-        m_ucs2_name = std::unique_ptr<ucs2_string_t>(new ucs2_string_t(m__io, this, m__root));
+        m_ucs2_name = new ucs2_string_t(m__io, this, m__root);
     }
     n_invoke_data_start = true;
     if (data_start_offset() >= 0) {
@@ -259,10 +313,16 @@ void ami_nvar_t::nvar_entry_body_t::_clean_up() {
     if (!n_ascii_name) {
     }
     if (!n_ucs2_name) {
+        if (m_ucs2_name) {
+            delete m_ucs2_name; m_ucs2_name = 0;
+        }
     }
     if (!n_invoke_data_start) {
     }
     if (f_extended_header_attributes && !n_extended_header_attributes) {
+        if (m_extended_header_attributes) {
+            delete m_extended_header_attributes; m_extended_header_attributes = 0;
+        }
     }
     if (f_extended_header_size_field && !n_extended_header_size_field) {
     }
@@ -276,23 +336,23 @@ void ami_nvar_t::nvar_entry_body_t::_clean_up() {
 
 ami_nvar_t::nvar_extended_attributes_t* ami_nvar_t::nvar_entry_body_t::extended_header_attributes() {
     if (f_extended_header_attributes)
-        return m_extended_header_attributes.get();
+        return m_extended_header_attributes;
     n_extended_header_attributes = true;
     if ( ((_parent()->attributes()->valid()) && (_parent()->attributes()->extended_header()) && (extended_header_size() >= (1 + 2))) ) {
         n_extended_header_attributes = false;
         std::streampos _pos = m__io->pos();
         m__io->seek((_io()->pos() - extended_header_size()));
-        m_extended_header_attributes = std::unique_ptr<nvar_extended_attributes_t>(new nvar_extended_attributes_t(m__io, this, m__root));
+        m_extended_header_attributes = new nvar_extended_attributes_t(m__io, this, m__root);
         m__io->seek(_pos);
         f_extended_header_attributes = true;
     }
-    return m_extended_header_attributes.get();
+    return m_extended_header_attributes;
 }
 
 int32_t ami_nvar_t::nvar_entry_body_t::data_start_offset() {
     if (f_data_start_offset)
         return m_data_start_offset;
-    m_data_start_offset = (int32_t)_io()->pos();
+    m_data_start_offset = _io()->pos();
     f_data_start_offset = true;
     return m_data_start_offset;
 }
@@ -353,7 +413,7 @@ uint8_t ami_nvar_t::nvar_entry_body_t::extended_header_checksum() {
 int32_t ami_nvar_t::nvar_entry_body_t::data_end_offset() {
     if (f_data_end_offset)
         return m_data_end_offset;
-    m_data_end_offset = (int32_t)_io()->pos();
+    m_data_end_offset = _io()->pos();
     f_data_end_offset = true;
     return m_data_end_offset;
 }
@@ -361,7 +421,7 @@ int32_t ami_nvar_t::nvar_entry_body_t::data_end_offset() {
 uint16_t ami_nvar_t::nvar_entry_body_t::extended_header_size() {
     if (f_extended_header_size)
         return m_extended_header_size;
-    m_extended_header_size = ((_parent()->attributes()->extended_header()) ? (((extended_header_size_field() >= (1 + 2)) ? (extended_header_size_field()) : (0))) : (0));
+    m_extended_header_size = (( ((_parent()->attributes()->extended_header()) && (_parent()->attributes()->valid()) && (_parent()->size() > (((4 + 2) + 4) + 2))) ) ? (((extended_header_size_field() >= (1 + 2)) ? (extended_header_size_field()) : (0))) : (0));
     f_extended_header_size = true;
     return m_extended_header_size;
 }

--- a/common/generated/ami_nvar.h
+++ b/common/generated/ami_nvar.h
@@ -1,10 +1,10 @@
-#pragma once
+#ifndef AMI_NVAR_H_
+#define AMI_NVAR_H_
 
 // This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
 
 #include "../kaitai/kaitaistruct.h"
 #include <stdint.h>
-#include <memory>
 #include <vector>
 
 #if KAITAI_STRUCT_VERSION < 9000L
@@ -20,7 +20,7 @@ public:
     class nvar_entry_t;
     class nvar_entry_body_t;
 
-    ami_nvar_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent = nullptr, ami_nvar_t* p__root = nullptr);
+    ami_nvar_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent = 0, ami_nvar_t* p__root = 0);
 
 private:
     void _read();
@@ -33,7 +33,7 @@ public:
 
     public:
 
-        nvar_attributes_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_t* p__parent = nullptr, ami_nvar_t* p__root = nullptr);
+        nvar_attributes_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_t* p__parent = 0, ami_nvar_t* p__root = 0);
 
     private:
         void _read();
@@ -71,7 +71,7 @@ public:
 
     public:
 
-        ucs2_string_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_body_t* p__parent = nullptr, ami_nvar_t* p__root = nullptr);
+        ucs2_string_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_body_t* p__parent = 0, ami_nvar_t* p__root = 0);
 
     private:
         void _read();
@@ -81,12 +81,12 @@ public:
         ~ucs2_string_t();
 
     private:
-        std::unique_ptr<std::vector<uint16_t>> m_ucs2_chars;
+        std::vector<uint16_t>* m_ucs2_chars;
         ami_nvar_t* m__root;
         ami_nvar_t::nvar_entry_body_t* m__parent;
 
     public:
-        std::vector<uint16_t>* ucs2_chars() const { return m_ucs2_chars.get(); }
+        std::vector<uint16_t>* ucs2_chars() const { return m_ucs2_chars; }
         ami_nvar_t* _root() const { return m__root; }
         ami_nvar_t::nvar_entry_body_t* _parent() const { return m__parent; }
     };
@@ -95,7 +95,7 @@ public:
 
     public:
 
-        nvar_extended_attributes_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_body_t* p__parent = nullptr, ami_nvar_t* p__root = nullptr);
+        nvar_extended_attributes_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_body_t* p__parent = 0, ami_nvar_t* p__root = 0);
 
     private:
         void _read();
@@ -127,7 +127,7 @@ public:
 
     public:
 
-        nvar_entry_t(kaitai::kstream* p__io, ami_nvar_t* p__parent = nullptr, ami_nvar_t* p__root = nullptr);
+        nvar_entry_t(kaitai::kstream* p__io, ami_nvar_t* p__parent = 0, ami_nvar_t* p__root = 0);
 
     private:
         void _read();
@@ -180,14 +180,14 @@ public:
         bool _is_null_next() { next(); return n_next; };
 
     private:
-        std::unique_ptr<nvar_attributes_t> m_attributes;
+        nvar_attributes_t* m_attributes;
         bool n_attributes;
 
     public:
         bool _is_null_attributes() { attributes(); return n_attributes; };
 
     private:
-        std::unique_ptr<nvar_entry_body_t> m_body;
+        nvar_entry_body_t* m_body;
         bool n_body;
 
     public:
@@ -210,7 +210,7 @@ public:
         bool _is_null__raw_body() { _raw_body(); return n__raw_body; };
 
     private:
-        std::unique_ptr<kaitai::kstream> m__io__raw_body;
+        kaitai::kstream* m__io__raw_body;
 
     public:
         std::string invoke_offset() const { return m_invoke_offset; }
@@ -218,20 +218,20 @@ public:
         std::string signature_rest() const { return m_signature_rest; }
         uint16_t size() const { return m_size; }
         uint64_t next() const { return m_next; }
-        nvar_attributes_t* attributes() const { return m_attributes.get(); }
-        nvar_entry_body_t* body() const { return m_body.get(); }
+        nvar_attributes_t* attributes() const { return m_attributes; }
+        nvar_entry_body_t* body() const { return m_body; }
         std::string invoke_end_offset() const { return m_invoke_end_offset; }
         ami_nvar_t* _root() const { return m__root; }
         ami_nvar_t* _parent() const { return m__parent; }
         std::string _raw_body() const { return m__raw_body; }
-        kaitai::kstream* _io__raw_body() const { return m__io__raw_body.get(); }
+        kaitai::kstream* _io__raw_body() const { return m__io__raw_body; }
     };
 
     class nvar_entry_body_t : public kaitai::kstruct {
 
     public:
 
-        nvar_entry_body_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_t* p__parent = nullptr, ami_nvar_t* p__root = nullptr);
+        nvar_entry_body_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_t* p__parent = 0, ami_nvar_t* p__root = 0);
 
     private:
         void _read();
@@ -242,7 +242,7 @@ public:
 
     private:
         bool f_extended_header_attributes;
-        std::unique_ptr<nvar_extended_attributes_t> m_extended_header_attributes;
+        nvar_extended_attributes_t* m_extended_header_attributes;
         bool n_extended_header_attributes;
 
     public:
@@ -355,7 +355,7 @@ public:
         bool _is_null_ascii_name() { ascii_name(); return n_ascii_name; };
 
     private:
-        std::unique_ptr<ucs2_string_t> m_ucs2_name;
+        ucs2_string_t* m_ucs2_name;
         bool n_ucs2_name;
 
     public:
@@ -377,7 +377,7 @@ public:
         uint8_t guid_index() const { return m_guid_index; }
         std::string guid() const { return m_guid; }
         std::string ascii_name() const { return m_ascii_name; }
-        ucs2_string_t* ucs2_name() const { return m_ucs2_name.get(); }
+        ucs2_string_t* ucs2_name() const { return m_ucs2_name; }
         std::string invoke_data_start() const { return m_invoke_data_start; }
         std::string data() const { return m_data; }
         ami_nvar_t* _root() const { return m__root; }
@@ -385,12 +385,14 @@ public:
     };
 
 private:
-    std::unique_ptr<std::vector<std::unique_ptr<nvar_entry_t>>> m_entries;
+    std::vector<nvar_entry_t*>* m_entries;
     ami_nvar_t* m__root;
     kaitai::kstruct* m__parent;
 
 public:
-    std::vector<std::unique_ptr<nvar_entry_t>>* entries() const { return m_entries.get(); }
+    std::vector<nvar_entry_t*>* entries() const { return m_entries; }
     ami_nvar_t* _root() const { return m__root; }
     kaitai::kstruct* _parent() const { return m__parent; }
 };
+
+#endif  // AMI_NVAR_H_

--- a/common/generated/ami_nvar.h
+++ b/common/generated/ami_nvar.h
@@ -1,10 +1,10 @@
-#ifndef AMI_NVAR_H_
-#define AMI_NVAR_H_
+#pragma once
 
 // This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
 
 #include "../kaitai/kaitaistruct.h"
 #include <stdint.h>
+#include <memory>
 #include <vector>
 
 #if KAITAI_STRUCT_VERSION < 9000L
@@ -20,7 +20,7 @@ public:
     class nvar_entry_t;
     class nvar_entry_body_t;
 
-    ami_nvar_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent = 0, ami_nvar_t* p__root = 0);
+    ami_nvar_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent = nullptr, ami_nvar_t* p__root = nullptr);
 
 private:
     void _read();
@@ -33,7 +33,7 @@ public:
 
     public:
 
-        nvar_attributes_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_t* p__parent = 0, ami_nvar_t* p__root = 0);
+        nvar_attributes_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_t* p__parent = nullptr, ami_nvar_t* p__root = nullptr);
 
     private:
         void _read();
@@ -71,7 +71,7 @@ public:
 
     public:
 
-        ucs2_string_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_body_t* p__parent = 0, ami_nvar_t* p__root = 0);
+        ucs2_string_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_body_t* p__parent = nullptr, ami_nvar_t* p__root = nullptr);
 
     private:
         void _read();
@@ -81,12 +81,12 @@ public:
         ~ucs2_string_t();
 
     private:
-        std::vector<uint16_t>* m_ucs2_chars;
+        std::unique_ptr<std::vector<uint16_t>> m_ucs2_chars;
         ami_nvar_t* m__root;
         ami_nvar_t::nvar_entry_body_t* m__parent;
 
     public:
-        std::vector<uint16_t>* ucs2_chars() const { return m_ucs2_chars; }
+        std::vector<uint16_t>* ucs2_chars() const { return m_ucs2_chars.get(); }
         ami_nvar_t* _root() const { return m__root; }
         ami_nvar_t::nvar_entry_body_t* _parent() const { return m__parent; }
     };
@@ -95,7 +95,7 @@ public:
 
     public:
 
-        nvar_extended_attributes_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_body_t* p__parent = 0, ami_nvar_t* p__root = 0);
+        nvar_extended_attributes_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_body_t* p__parent = nullptr, ami_nvar_t* p__root = nullptr);
 
     private:
         void _read();
@@ -127,7 +127,7 @@ public:
 
     public:
 
-        nvar_entry_t(kaitai::kstream* p__io, ami_nvar_t* p__parent = 0, ami_nvar_t* p__root = 0);
+        nvar_entry_t(kaitai::kstream* p__io, ami_nvar_t* p__parent = nullptr, ami_nvar_t* p__root = nullptr);
 
     private:
         void _read();
@@ -180,14 +180,14 @@ public:
         bool _is_null_next() { next(); return n_next; };
 
     private:
-        nvar_attributes_t* m_attributes;
+        std::unique_ptr<nvar_attributes_t> m_attributes;
         bool n_attributes;
 
     public:
         bool _is_null_attributes() { attributes(); return n_attributes; };
 
     private:
-        nvar_entry_body_t* m_body;
+        std::unique_ptr<nvar_entry_body_t> m_body;
         bool n_body;
 
     public:
@@ -210,7 +210,7 @@ public:
         bool _is_null__raw_body() { _raw_body(); return n__raw_body; };
 
     private:
-        kaitai::kstream* m__io__raw_body;
+        std::unique_ptr<kaitai::kstream> m__io__raw_body;
 
     public:
         std::string invoke_offset() const { return m_invoke_offset; }
@@ -218,20 +218,20 @@ public:
         std::string signature_rest() const { return m_signature_rest; }
         uint16_t size() const { return m_size; }
         uint64_t next() const { return m_next; }
-        nvar_attributes_t* attributes() const { return m_attributes; }
-        nvar_entry_body_t* body() const { return m_body; }
+        nvar_attributes_t* attributes() const { return m_attributes.get(); }
+        nvar_entry_body_t* body() const { return m_body.get(); }
         std::string invoke_end_offset() const { return m_invoke_end_offset; }
         ami_nvar_t* _root() const { return m__root; }
         ami_nvar_t* _parent() const { return m__parent; }
         std::string _raw_body() const { return m__raw_body; }
-        kaitai::kstream* _io__raw_body() const { return m__io__raw_body; }
+        kaitai::kstream* _io__raw_body() const { return m__io__raw_body.get(); }
     };
 
     class nvar_entry_body_t : public kaitai::kstruct {
 
     public:
 
-        nvar_entry_body_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_t* p__parent = 0, ami_nvar_t* p__root = 0);
+        nvar_entry_body_t(kaitai::kstream* p__io, ami_nvar_t::nvar_entry_t* p__parent = nullptr, ami_nvar_t* p__root = nullptr);
 
     private:
         void _read();
@@ -242,7 +242,7 @@ public:
 
     private:
         bool f_extended_header_attributes;
-        nvar_extended_attributes_t* m_extended_header_attributes;
+        std::unique_ptr<nvar_extended_attributes_t> m_extended_header_attributes;
         bool n_extended_header_attributes;
 
     public:
@@ -355,7 +355,7 @@ public:
         bool _is_null_ascii_name() { ascii_name(); return n_ascii_name; };
 
     private:
-        ucs2_string_t* m_ucs2_name;
+        std::unique_ptr<ucs2_string_t> m_ucs2_name;
         bool n_ucs2_name;
 
     public:
@@ -377,7 +377,7 @@ public:
         uint8_t guid_index() const { return m_guid_index; }
         std::string guid() const { return m_guid; }
         std::string ascii_name() const { return m_ascii_name; }
-        ucs2_string_t* ucs2_name() const { return m_ucs2_name; }
+        ucs2_string_t* ucs2_name() const { return m_ucs2_name.get(); }
         std::string invoke_data_start() const { return m_invoke_data_start; }
         std::string data() const { return m_data; }
         ami_nvar_t* _root() const { return m__root; }
@@ -385,14 +385,12 @@ public:
     };
 
 private:
-    std::vector<nvar_entry_t*>* m_entries;
+    std::unique_ptr<std::vector<std::unique_ptr<nvar_entry_t>>> m_entries;
     ami_nvar_t* m__root;
     kaitai::kstruct* m__parent;
 
 public:
-    std::vector<nvar_entry_t*>* entries() const { return m_entries; }
+    std::vector<std::unique_ptr<nvar_entry_t>>* entries() const { return m_entries.get(); }
     ami_nvar_t* _root() const { return m__root; }
     kaitai::kstruct* _parent() const { return m__parent; }
 };
-
-#endif  // AMI_NVAR_H_

--- a/common/ksy/ami_nvar.ksy
+++ b/common/ksy/ami_nvar.ksy
@@ -125,7 +125,7 @@ types:
       and _parent.attributes.extended_header
       and _parent.size > sizeof<u4> + sizeof<u2> + sizeof<u4> + sizeof<u2>
     extended_header_size:
-     value: '_parent.attributes.extended_header ? (extended_header_size_field >= sizeof<nvar_extended_attributes> + sizeof<u2> ? extended_header_size_field : 0) : 0'
+     value: '(_parent.attributes.extended_header and _parent.attributes.valid and (_parent.size > sizeof<u4> + sizeof<u2> + sizeof<u4> + sizeof<u2>)) ? (extended_header_size_field >= sizeof<nvar_extended_attributes> + sizeof<u2> ? extended_header_size_field : 0) : 0'
     extended_header_attributes:
      pos: _io.pos - extended_header_size
      type: nvar_extended_attributes


### PR DESCRIPTION
modify 1 line in ami_nvar.ksy (line 128).

Bug scenario:
nvar_entry.attributes.valid = 0
nvar_entry.attributes.extended_header = 1

Now, extended_header_size_field 's value is undefined, as defined in ami_nvar.ksy
```
extended_header_size_field:
     pos: _io.pos - sizeof<u2>
     type: u2
     if: _parent.attributes.valid
      and _parent.attributes.extended_header
      and _parent.size > sizeof<u4> + sizeof<u2> + sizeof<u4> + sizeof<u2>
```
but this value would be used by other instances, e.g. extended_header_size, as defined in ami_nvar.ksy
```
extended_header_size:
     value: '_parent.attributes.extended_header ? (extended_header_size_field >= sizeof<nvar_extended_attributes> + sizeof<u2> ? extended_header_size_field : 0) : 0'
```
finally leads to parse error/exception or program crash.

