### PR TITLE
Fix CPD Manifest's partition offset

### DIFF
--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -4673,7 +4673,7 @@ make_partition_table_consistent:
                                         manifestHeader->ExponentSize * (UINT32)sizeof(UINT32), manifestHeader->ExponentSize * (UINT32)sizeof(UINT32));
                         
                         // Add tree item
-                        UModelIndex partitionIndex = model->addItem(localOffset + partitions[i].ptEntry.Offset.Offset, Types::CpdPartition, Subtypes::ManifestCpdPartition, name, UString(), info, header, body, UByteArray(), Fixed, parent);
+                        UModelIndex partitionIndex = model->addItem(localOffset + header.size() + partitions[i].ptEntry.Offset.Offset, Types::CpdPartition, Subtypes::ManifestCpdPartition, name, UString(), info, header, body, UByteArray(), Fixed, parent);
                         
                         // Parse data as extensions area
                         parseCpdExtensionsArea(partitionIndex);


### PR DESCRIPTION
The header size needs to be probably added here, maybe it was forgotten ?

This is needed in order to get the proper base address of a CPD_EXT_IFWI_PARTITION_MANIFEST structure in the image for example in that specific case.

If I don't do this, it points to a meaningless address.

Let me know if there can be any issues with this.