### PR TITLE
Fix CPD Extension offset (reverts 29915ca)

### DIFF
--- a/common/ffsparser.h
+++ b/common/ffsparser.h
@@ -130,7 +130,7 @@ private:
 
     USTATUS parseBpdtRegion(const UByteArray & region, const UINT32 localOffset, const UINT32 sbpdtOffsetFixup, const UModelIndex & parent, UModelIndex & index);
     USTATUS parseCpdRegion(const UByteArray & region, const UINT32 localOffset, const UModelIndex & parent, UModelIndex & index);
-    USTATUS parseCpdExtensionsArea(const UModelIndex & index);
+    USTATUS parseCpdExtensionsArea(const UModelIndex & index, const UINT32 localOffset);
     USTATUS parseSignedPackageInfoData(const UModelIndex & index);
     
     USTATUS parseRawArea(const UModelIndex & index);


### PR DESCRIPTION
The CPD Extensions should have the header size added as an offset instead.
More details here: https://github.com/LongSoft/UEFITool/pull/374#issuecomment-1685100216

Perhaps, I'm not sure for the second call of parseCpdExtensionsArea since I didn't encounter it yet but right now it should be fine as it is.