### PR TITLE
Define ACCESSPERMS When Compiling With musl

### DIFF
--- a/common/filesystem.cpp
+++ b/common/filesystem.cpp
@@ -75,6 +75,9 @@ UString getAbsPath(const UString & path)
 #else
 #include <unistd.h>
 #include <stdlib.h>
+#if !defined(ACCESSPERMS)
+#define ACCESSPERMS (S_IRWXU|S_IRWXG|S_IRWXO)
+#endif
 bool isExistOnFs(const UString & path) 
 {
     struct stat buf;


### PR DESCRIPTION
Compiling UEFITool fails on Linux distros using the musl libc, such as Alpine, due to ACCESSPERMS not being defined in `sys/stat.h`:

```
uefitool/common/filesystem.cpp: In function 'bool makeDirectory(const Bstrlib::CBString&)':
uefitool/common/filesystem.cpp:86:38: error: 'ACCESSPERMS' was not declared in this scope
   86 |     return (mkdir(dir.toLocal8Bit(), ACCESSPERMS) == 0);
      |                                      ^~~~~~~~~~~
```

This PR creates a definition for ACCESSPERMS, allowing compilation to complete.