### PR TITLE
Remove PATH_MAX from realpath

### DIFF
--- a/common/filesystem.cpp
+++ b/common/filesystem.cpp
@@ -100,10 +100,14 @@ bool changeDirectory(const UString & dir)
 }
 
 UString getAbsPath(const UString & path) {
-    char abs[PATH_MAX] = {};
+    char * abs = realpath(path.toLocal8Bit(), nullptr);
     // Last is a non-standard extension for non-existent files
-    if (realpath(path.toLocal8Bit(), abs) || abs[0] != '\0')
-        return UString(abs);
-    return path;
+    UString new_path;
+    if (abs)
+        new_path = UString(abs);
+    else
+        new_path = path;
+    free(abs);
+    return new_path;
 }
 #endif


### PR DESCRIPTION
POSIX.1-2008 ensures realpath() give a dynamically allocated buffer if NULL is passed, which avoids using PATH_MAX, which may be too large to fit in stack, or even undefined on some systems.