### PR TITLE
PE_IMAGE: Add LoongArch definitions

### DIFF
--- a/common/peimage.cpp
+++ b/common/peimage.cpp
@@ -30,6 +30,8 @@ UString machineTypeToUString(UINT16 machineType)
         case EFI_IMAGE_FILE_MACHINE_RISCV32:     return UString("RISC-V 32-bit");
         case EFI_IMAGE_FILE_MACHINE_RISCV64:     return UString("RISC-V 64-bit");
         case EFI_IMAGE_FILE_MACHINE_RISCV128:    return UString("RISC-V 128-bit");
+        case EFI_IMAGE_FILE_MACHINE_LOONGARCH32: return UString("LoongArch 32-bit");
+        case EFI_IMAGE_FILE_MACHINE_LOONGARCH64: return UString("LoongArch 64-bit");
     }
     return usprintf("Unknown %04Xh", machineType);
 }

--- a/common/peimage.h
+++ b/common/peimage.h
@@ -49,6 +49,8 @@ extern UString machineTypeToUString(UINT16 machineType);
 #define EFI_IMAGE_FILE_MACHINE_RISCV32        0x5032 // RISC-V 32-bit
 #define EFI_IMAGE_FILE_MACHINE_RISCV64        0x5064 // RISC-V 64-bit
 #define EFI_IMAGE_FILE_MACHINE_RISCV128       0x5128 // RISC-V 128-bit
+#define EFI_IMAGE_FILE_MACHINE_LOONGARCH32    0x6232 // LoongArch 32-bit
+#define EFI_IMAGE_FILE_MACHINE_LOONGARCH64    0x6264 // LoongArch 64-bit
 
 //
 // EXE file formats


### PR DESCRIPTION
For definitions of PE/COFF, see the "Machine Types" sections of this URL for LOONGARCH values:
REF: https://docs.microsoft.com/en-us/windows/win32/debug/pe-format

BTW, see the UEFI V2.10 -> 18.2.2 sections of this URL for LOONGARCH definitions: https://uefi.org/specs/UEFI/2.10/18_Protocols_Debugger_Support.html