### PR TITLE
Refactored UI with docks, added hex view dock, small menus fixes - cl…

### DIFF
--- a/UEFITool/uefitool.cpp
+++ b/UEFITool/uefitool.cpp
@@ -1241,10 +1241,11 @@ void UEFITool::contextMenuEvent(QContextMenuEvent* event)
 
     if (menu) {
         QList<QAction*> actions = menu->actions();
-        QAction s = QAction(nullptr);
-        s.setSeparator(true);
+        QAction *separator = new QAction(nullptr);
+        separator->setSeparator(true);
         QMenu::exec(
-            actions << &s << ui->actionExpandRecursively << ui->actionCollapseRecursively, gp);
+            actions << separator << ui->actionExpandRecursively << ui->actionCollapseRecursively, gp);
+        delete separator;
     }
 }
 
@@ -1274,7 +1275,9 @@ void UEFITool::readSettings()
     resetDocks();
 
     restoreGeometry(settings.value("mainWindow/geometry").toByteArray());
-    restoreState(settings.value("mainWindow/windowState").toByteArray());
+    QByteArray state = settings.value("mainWindow/windowState").toByteArray();
+    if (state.size() > 0x100)
+        restoreState(state);
     ui->structureTreeView->setColumnWidth(0, settings.value("tree/columnWidth0", ui->structureTreeView->columnWidth(0)).toInt());
     ui->structureTreeView->setColumnWidth(1, settings.value("tree/columnWidth1", ui->structureTreeView->columnWidth(1)).toInt());
     ui->structureTreeView->setColumnWidth(2, settings.value("tree/columnWidth2", ui->structureTreeView->columnWidth(2)).toInt());

--- a/UEFITool/uefitool.cpp
+++ b/UEFITool/uefitool.cpp
@@ -36,6 +36,7 @@ markingEnabled(true)
     ui->setupUi(this);
     setTabPosition(Qt::AllDockWidgetAreas, QTabWidget::North);
     ui->hexViewWidgetContents->layout()->addWidget(&selectedHexView);
+    dockTimer.setSingleShot(true);
     searchDialog = new SearchDialog(this);
     hexViewDialog = new HexViewDialog(this);
     goToAddressDialog = new GoToAddressDialog(this);
@@ -106,6 +107,7 @@ markingEnabled(true)
         connect(dock, SIGNAL(topLevelChanged(bool)), this, SLOT(onDockStateChange(bool)));
         connect(dock, SIGNAL(visibilityChanged(bool)), this, SLOT(onDockStateChange(bool)));
     }
+    connect(&dockTimer, SIGNAL(timeout()), this, SLOT(checkAndUpdateDocks()));
     connect(QCoreApplication::instance(), SIGNAL(aboutToQuit()), this, SLOT(writeSettings()));
     
     // Enable Drag-and-Drop actions
@@ -154,8 +156,14 @@ void UEFITool::init()
     ui->infoEdit->clear();
     ui->securityEdit->clear();
     contextEventWidget = nullptr;
-    for (auto dock : findChildren<QDockWidget*>())
+    bool wayland = QGuiApplication::platformName().contains("wayland", Qt::CaseInsensitive);
+    for (auto dock : findChildren<QDockWidget*>()) {
         enableDock(dock, false);
+        if (wayland) {
+            // floating QDockWidgets are defective in Wayland
+            dock->setFeatures(dock->features() & ~QDockWidget::DockWidgetFloatable);
+        }
+    }
     
     // Set window title
     setWindowTitle(tr("UEFITool %1").arg(version));
@@ -795,56 +803,96 @@ void UEFITool::onDockStateChange(const bool topLevel)
 
 void UEFITool::updateDock(QDockWidget* const dock)
 {
-    if (dock->isHidden())
+    if (!dock || dock->isHidden())
+        return;
+    if (!dock->widget() || !dock->widget()->layout())
         return;
 
     QWidget *widget = dock->titleBarWidget();
     QMargins margins = dock->widget()->layout()->contentsMargins();
     int ref = margins.left();
     margins.setTop(ref);
+
     if (widget) {
         dock->setTitleBarWidget(nullptr);
         delete widget;
     }
+
+    // Floating? Using built-in title
     if (dock->isFloating()) {
         dock->widget()->layout()->setContentsMargins(margins);
+        return;
     }
-    else {
-        QWidget* titleBar = new QWidget(dock);
-        QHBoxLayout* layout = new QHBoxLayout(titleBar);
-        dock->setTitleBarWidget(titleBar);
-        if (!tabifiedDockWidgets(dock).isEmpty()) {
-            layout->setContentsMargins(0, ref, 0, 0);
-            dock->widget()->layout()->setContentsMargins(ref, 0, ref, ref);
-            for (auto tabBar : findChildren<QTabBar*>()) {
-                for (int i = tabBar->count() - 1; i >= 0; i--) {
-                    // hope all docks have different titles
-                    if (dock->windowTitle() == tabBar->tabText(i)) {
-                        QPalette palette = QApplication::palette();
-                        tabBar->setTabTextColor(i, !dock->isEnabled()
-                            ? palette.color(QPalette::Disabled, QPalette::WindowText)
-                                : dock->isVisible()
-                                    ? palette.color(QPalette::Active, QPalette::WindowText)
-                                        : palette.color(QPalette::Inactive, QPalette::WindowText));
-                        return;
-                    }
+
+    widget = new QWidget();
+    auto layout = new QHBoxLayout(widget);
+    dock->setTitleBarWidget(widget);
+    QString titleText = dock->windowTitle();
+
+    // Tabified? Using blank title
+    if (!tabifiedDockWidgets(dock).isEmpty()) {
+        for (auto tabBar : findChildren<QTabBar*>()) {
+            for (int i = tabBar->count() - 1; i >= 0; i--) {
+                // Hope all docks have different titles
+                if (titleText == tabBar->tabText(i)) {
+                    layout->setContentsMargins(0, ref, 0, 0);
+                    dock->widget()->layout()->setContentsMargins(ref, 0, ref, ref);
+                    QPalette palette = QApplication::palette();
+                    tabBar->setTabTextColor(i, !dock->isEnabled()
+                        ? palette.color(QPalette::Disabled, QPalette::WindowText)
+                            : dock->isVisible()
+                                ? palette.color(QPalette::Active, QPalette::WindowText)
+                                    : palette.color(QPalette::Inactive, QPalette::WindowText));
+                    return;
                 }
             }
         }
-        else {
-            layout->setContentsMargins(ref, ref / 2, ref, 0);
-            auto titleLabel = new QLabel(dock->windowTitle());
-            titleLabel->setFont(QApplication::font());
-            layout->addWidget(titleLabel);
-            dock->widget()->layout()->setContentsMargins(ref, ref / 2, ref, ref);
-        }
     }
+
+    // Docked? Setup own title with text
+    layout->setContentsMargins(ref, ref / 2, ref, 0);
+    auto titleLabel = new QLabel(titleText);
+    titleLabel->setFont(QApplication::font());
+    layout->addWidget(titleLabel);
+    dock->widget()->layout()->setContentsMargins(ref, ref / 2, ref, ref);
+
+}
+
+bool UEFITool::checkDock(QDockWidget* const dock)
+{
+    if (!dock || dock->isHidden())
+        return true;
+    if (!dock->widget() || !dock->widget()->layout())
+        return true;
+
+    QWidget* widget = dock->titleBarWidget();
+    // floating dock - no title widget
+    if (dock->isFloating())
+        return widget ? false : true;
+    // tabified dock - title widget with blank layout
+    if (!widget || !widget->layout())
+        return false;
+    if (!tabifiedDockWidgets(dock).isEmpty())
+        return true;
+    // sticked dock - title widget with layout with text widget(s)
+    return widget->layout()->findChildren<QLabel*>().isEmpty() ? false : true;
 }
 
 void UEFITool::enableDock(QDockWidget* const dock, const bool enable)
 {
+    if (!dock)
+        return;
+
     dock->setEnabled(enable);
     updateDock(dock);
+}
+
+void UEFITool::checkAndUpdateDocks()
+{
+    for (auto dock : findChildren<QDockWidget*>()) {
+        if (!checkDock(dock))
+            updateDock(dock);
+    }
 }
 
 void UEFITool::resetDocks()
@@ -1159,6 +1207,9 @@ void UEFITool::scrollTreeView(QListWidgetItem* item)
 
 void UEFITool::scrollTreeView(QTableWidgetItem* item)
 {
+    if (!item)
+        return;
+
     QByteArray second = item->data(Qt::UserRole).toByteArray();
     QModelIndex *index = (QModelIndex *)second.data();
     if (index && index->isValid()) {
@@ -1169,6 +1220,9 @@ void UEFITool::scrollTreeView(QTableWidgetItem* item)
 
 void UEFITool::contextMenuEvent(QContextMenuEvent* event)
 {
+    if (!event)
+        return;
+
     QPoint gp = event->globalPos();
     for (QListWidget* list : { ui->parserMessagesListWidget, ui->finderMessagesListWidget, ui->builderMessagesListWidget}) {
         // The checks involving underMouse do not work well enough on macOS, and result in right-click sometimes
@@ -1269,7 +1323,7 @@ void UEFITool::readSettings()
 
     restoreGeometry(settings.value("mainWindow/geometry").toByteArray());
     QByteArray state = settings.value("mainWindow/windowState").toByteArray();
-    if (state.size() > 0x100)
+    if (state.size() > 0x100)   // stupid check for transition from classic UI to docks
         restoreState(state);
     ui->structureTreeView->setColumnWidth(0, settings.value("tree/columnWidth0", ui->structureTreeView->columnWidth(0)).toInt());
     ui->structureTreeView->setColumnWidth(1, settings.value("tree/columnWidth1", ui->structureTreeView->columnWidth(1)).toInt());

--- a/UEFITool/uefitool.cpp
+++ b/UEFITool/uefitool.cpp
@@ -153,10 +153,7 @@ void UEFITool::init()
     ui->fitTableWidget->setColumnCount(0);
     ui->infoEdit->clear();
     ui->securityEdit->clear();
-    ui->parserMessagesListWidget->setProperty(propTab(), TAB_PARSER);
-    ui->finderMessagesListWidget->setProperty(propTab(), TAB_SEARCH);
-    ui->builderMessagesListWidget->setProperty(propTab(), TAB_BUILDER);
-    setProperty(propTab(), -1);
+    contextEventWidget = nullptr;
     for (auto dock : findChildren<QDockWidget*>())
         enableDock(dock, false);
     
@@ -999,20 +996,19 @@ void UEFITool::enableMessagesCopyActions(QListWidgetItem* item)
 {
     ui->menuMessageActions->setEnabled(item != NULL);
     ui->actionMessagesCopy->setEnabled(item != NULL);
-    ui->actionMessagesCopyAll->setEnabled(item->listWidget()->count() > 0);
-    ui->actionMessagesClear->setEnabled(item->listWidget()->count() > 0);
+    ui->actionMessagesCopyAll->setEnabled(item != NULL);
+    ui->actionMessagesClear->setEnabled(item != NULL);
 }
 
 void UEFITool::copyMessage()
 {
     clipboard->clear();
 
-    int tab = property(propTab()).toInt();
-    if (tab == TAB_PARSER) // Parser tab
+    if (contextEventWidget == ui->parserMessagesListWidget) // Parser tab
         clipboard->setText(ui->parserMessagesListWidget->currentItem()->text());
-    else if (tab == TAB_SEARCH) // Search tab
+    else if (contextEventWidget == ui->finderMessagesListWidget) // Search tab
         clipboard->setText(ui->finderMessagesListWidget->currentItem()->text());
-    else if (tab == TAB_BUILDER) // Builder tab
+    else if (contextEventWidget == ui->builderMessagesListWidget) // Builder tab
         clipboard->setText(ui->builderMessagesListWidget->currentItem()->text());
 }
 
@@ -1021,18 +1017,17 @@ void UEFITool::copyAllMessages()
     QString text;
     clipboard->clear();
 
-    int tab = property(propTab()).toInt();
-    if (tab == TAB_PARSER) { // Parser tab
+    if (contextEventWidget == ui->parserMessagesListWidget) { // Parser tab
         for (INT32 i = 0; i < ui->parserMessagesListWidget->count(); i++)
             text.append(ui->parserMessagesListWidget->item(i)->text()).append("\n");
         clipboard->setText(text);
     }
-    else if (tab == TAB_SEARCH) {  // Search tab
+    else if (contextEventWidget == ui->finderMessagesListWidget) {  // Search tab
         for (INT32 i = 0; i < ui->finderMessagesListWidget->count(); i++)
             text.append(ui->finderMessagesListWidget->item(i)->text()).append("\n");
         clipboard->setText(text);
     }
-    else if (tab == TAB_BUILDER) {  // Builder tab
+    else if (contextEventWidget == ui->builderMessagesListWidget) {  // Builder tab
         for (INT32 i = 0; i < ui->builderMessagesListWidget->count(); i++)
             text.append(ui->builderMessagesListWidget->item(i)->text()).append("\n");
         clipboard->setText(text);
@@ -1041,16 +1036,15 @@ void UEFITool::copyAllMessages()
 
 void UEFITool::clearMessages()
 {
-    int tab = property(propTab()).toInt();
-    if (tab == TAB_PARSER) { // Parser tab
+    if (contextEventWidget == ui->parserMessagesListWidget) { // Parser tab
         if (ffsParser) ffsParser->clearMessages();
         ui->parserMessagesListWidget->clear();
     }
-    else if (tab == TAB_SEARCH) {  // Search tab
+    else if (contextEventWidget == ui->finderMessagesListWidget) {  // Search tab
         if (ffsFinder) ffsFinder->clearMessages();
         ui->finderMessagesListWidget->clear();
     }
-    else if (tab == TAB_BUILDER) {  // Builder tab
+    else if (contextEventWidget == ui->builderMessagesListWidget) {  // Builder tab
         if (ffsBuilder) ffsBuilder->clearMessages();
         ui->builderMessagesListWidget->clear();
     }
@@ -1181,13 +1175,12 @@ void UEFITool::contextMenuEvent(QContextMenuEvent* event)
         // not showing any context menu at all. Most likely it is a bug in Qt, which does not affect other systems.
         // For this reason we reimplement this manually.
         if (list->rect().contains(list->mapFromGlobal(gp))) {
-            int tab = list->property(propTab()).toInt();
-            setProperty(propTab(), QVariant::fromValue(tab));
+            contextEventWidget = list;
             QListWidgetItem* item = list->itemAt(list->mapFromGlobal(gp));
             if (item)
                 enableMessagesCopyActions(item);
             ui->menuMessageActions->exec(gp);
-            setProperty(propTab(), -1);
+            contextEventWidget = nullptr;
             break;
         }
     }

--- a/UEFITool/uefitool.cpp
+++ b/UEFITool/uefitool.cpp
@@ -34,6 +34,8 @@ markingEnabled(true)
     
     // Create UI
     ui->setupUi(this);
+    setTabPosition(Qt::AllDockWidgetAreas, QTabWidget::North);
+    ui->hexViewWidgetContents->layout()->addWidget(&selectedHexView);
     searchDialog = new SearchDialog(this);
     hexViewDialog = new HexViewDialog(this);
     goToAddressDialog = new GoToAddressDialog(this);
@@ -79,8 +81,8 @@ markingEnabled(true)
     connect(ui->actionGenerateReport, SIGNAL(triggered()), this, SLOT(generateReport()));
     connect(ui->actionToggleBootGuardMarking, SIGNAL(toggled(bool)), this, SLOT(toggleBootGuardMarking(bool)));
     connect(ui->actionCopyItemName, SIGNAL(triggered()), this, SLOT(copyItemName()));
-    connect(ui->actionExpandWholeSection, SIGNAL(triggered()), this, SLOT(expandWholeSection()));
-    connect(ui->actionCollapseWholeSection, SIGNAL(triggered()), this, SLOT(collapseWholeSection()));
+    connect(ui->actionExpandRecursively, SIGNAL(triggered()), this, SLOT(expandRecursively()));
+    connect(ui->actionCollapseRecursively, SIGNAL(triggered()), this, SLOT(collapseRecursively()));
     connect(ui->actionClearRecentlyOpenedFilesList, SIGNAL(triggered()), this, SLOT(clearRecentlyOpenedFilesList()));
     connect(ui->actionHashCrc32, SIGNAL(triggered()), this, SLOT(hashCrc32()));
     connect(ui->actionHashSha1, SIGNAL(triggered()), this, SLOT(hashSha1()));
@@ -100,13 +102,17 @@ markingEnabled(true)
     connect(ui->actionUncompressedHashSha384, SIGNAL(triggered()), this, SLOT(hashUncompressedSha384()));
     connect(ui->actionUncompressedHashSha512, SIGNAL(triggered()), this, SLOT(hashUncompressedSha512()));
     connect(ui->actionUncompressedHashSm3, SIGNAL(triggered()), this, SLOT(hashUncompressedSm3()));
+    for (auto dock : findChildren<QDockWidget*>()) {
+        connect(dock, SIGNAL(topLevelChanged(bool)), this, SLOT(onDockStateChange(bool)));
+        connect(dock, SIGNAL(visibilityChanged(bool)), this, SLOT(onDockStateChange(bool)));
+    }
     connect(QCoreApplication::instance(), SIGNAL(aboutToQuit()), this, SLOT(writeSettings()));
     
     // Enable Drag-and-Drop actions
     setAcceptDrops(true);
     
     // Disable Builder tab, doesn't work right now
-    ui->messagesTabWidget->setTabEnabled(TAB_BUILDER, false);
+    enableDock(ui->builderMessagesDock, false);
     
     // Set current directory
     currentDir = ".";
@@ -147,10 +153,12 @@ void UEFITool::init()
     ui->fitTableWidget->setColumnCount(0);
     ui->infoEdit->clear();
     ui->securityEdit->clear();
-    ui->messagesTabWidget->setTabEnabled(TAB_FIT, false);
-    ui->messagesTabWidget->setTabEnabled(TAB_SECURITY, false);
-    ui->messagesTabWidget->setTabEnabled(TAB_SEARCH, false);
-    ui->messagesTabWidget->setTabEnabled(TAB_BUILDER, false);
+    ui->parserMessagesListWidget->setProperty(propTab(), TAB_PARSER);
+    ui->finderMessagesListWidget->setProperty(propTab(), TAB_SEARCH);
+    ui->builderMessagesListWidget->setProperty(propTab(), TAB_BUILDER);
+    setProperty(propTab(), -1);
+    for (auto dock : findChildren<QDockWidget*>())
+        enableDock(dock, false);
     
     // Set window title
     setWindowTitle(tr("UEFITool %1").arg(version));
@@ -197,7 +205,6 @@ void UEFITool::init()
     connect(ui->builderMessagesListWidget, SIGNAL(itemDoubleClicked(QListWidgetItem*)), this, SLOT(scrollTreeView(QListWidgetItem*)));
     connect(ui->builderMessagesListWidget, SIGNAL(itemEntered(QListWidgetItem*)),       this, SLOT(enableMessagesCopyActions(QListWidgetItem*)));
     connect(ui->fitTableWidget, SIGNAL(itemDoubleClicked(QTableWidgetItem*)), this, SLOT(scrollTreeView(QTableWidgetItem*)));
-    connect(ui->messagesTabWidget, SIGNAL(currentChanged(int)), this, SLOT(currentTabChanged(int)));
     
     // Allow enter/return pressing to scroll tree view
     ui->parserMessagesListWidget->installEventFilter(this);
@@ -241,6 +248,10 @@ void UEFITool::updateUiForNewColorScheme(Qt::ColorScheme scheme)
 {
     model->setMarkingDarkMode(scheme == Qt::ColorScheme::Dark);
     QApplication::setPalette(QApplication::style()->standardPalette());
+
+    QModelIndex current = ui->structureTreeView->selectionModel()->currentIndex();
+    selectedHexView.setBackground(0, model->header(current).size(),
+        model->markingDarkMode() ? Qt::darkGreen : Qt::green);
 }
 #endif
 
@@ -249,6 +260,7 @@ void UEFITool::updateRecentFilesMenu(const QString& fileName)
     // Update list
     if (!fileName.isEmpty()) {
         recentFiles.removeAll(fileName);
+        recentFiles.removeAll(QDir::toNativeSeparators(fileName));
         recentFiles.prepend(fileName);
         while (recentFiles.size() > 21) {
             recentFiles.removeLast();
@@ -263,19 +275,25 @@ void UEFITool::updateRecentFilesMenu(const QString& fileName)
     recentFileActions.clear();
 
     if (!recentFiles.isEmpty()) {
+        int key = 0;
+
         // Enable "Clear recently opened files list" action
         ui->actionClearRecentlyOpenedFilesList->setEnabled(true);
         
         // Insert new actions before "Clear recently opened files list"
         for (const QString& path : recentFiles) {
             QAction* action = new QAction(QDir::toNativeSeparators(path), this);
+            if (++key < 10)
+                action->setShortcut(QKeySequence(Qt::ALT | (Qt::Key_0 + key)));
+            else if (key == 10)
+                action->setShortcut(QKeySequence(Qt::ALT | Qt::Key_0));
             connect(action, SIGNAL(triggered()), this, SLOT(openRecentImageFile()));
             action->setData(path);
             ui->menuFile->insertAction(ui->actionClearRecentlyOpenedFilesList, action);
             recentFileActions.append(action);
         }
-        // Finally, insert a separator after the list and before "Quit"
-        recentFileActions.append(ui->menuFile->insertSeparator(ui->actionQuit));
+        // Finally, insert a separator after the list and before "Clear recently opened files list" action
+        recentFileActions.append(ui->menuFile->insertSeparator(ui->actionClearRecentlyOpenedFilesList));
     }
     else {
         // Disable "Clear recently opened files list" action
@@ -304,6 +322,14 @@ void UEFITool::populateUi(const QModelIndex &current)
     
     // Set info text
     ui->infoEdit->setPlainText(model->info(current));
+    enableDock(ui->infoDock, true);
+
+    // Set Hex view
+    selectedHexView.clearMetadata();
+    selectedHexView.setBackground(0, model->header(current).size(),
+        model->markingDarkMode() ? Qt::darkGreen : Qt::green);
+    selectedHexView.setData(model->header(current) + model->body(current) + model->tail(current));
+    enableDock(ui->hexViewDock, true);
     
     // Enable menus
     ui->menuCapsuleActions->setEnabled(type == Types::Capsule);
@@ -362,8 +388,8 @@ void UEFITool::populateUi(const QModelIndex &current)
     ui->actionExtract->setDisabled(empty);
     ui->actionGoToData->setEnabled(type == Types::NvarEntry && subtype == Subtypes::LinkNvarEntry);
     ui->actionCopyItemName->setDisabled(model->name(current).isEmpty());
-    ui->actionExpandWholeSection->setEnabled(model->rowCount(current) > 0);
-    ui->actionCollapseWholeSection->setEnabled(model->rowCount(current) > 0);
+    ui->actionExpandRecursively->setEnabled(model->rowCount(current) > 0);
+    ui->actionCollapseRecursively->setEnabled(model->rowCount(current) > 0);
     ui->actionHashCrc32->setDisabled(empty);
     ui->actionHashSha1->setDisabled(empty);
     ui->actionHashSha256->setDisabled(empty);
@@ -404,9 +430,53 @@ void UEFITool::populateUi(const QModelIndex &current)
 
 void UEFITool::search()
 {
+    QSettings settings(this);
+    searchDialog->restoreGeometry(settings.value("searchDialog/geometry").toByteArray());
+    searchDialog->ui->tabWidget->setCurrentIndex(settings.value("searchDialog/currentScopeMode").toInt());
+    UINT8 mode = settings.value("searchDialog/hexScopeMode", SEARCH_MODE_ALL).toUInt();
+    searchDialog->ui->hexScopeHeaderRadioButton->setChecked(mode <= SEARCH_MODE_HEADER);
+    searchDialog->ui->hexScopeBodyRadioButton->setChecked(mode == SEARCH_MODE_BODY);
+    searchDialog->ui->hexScopeFullRadioButton->setChecked(mode >= SEARCH_MODE_ALL);
+    mode = settings.value("searchDialog/guidScopeMode", SEARCH_MODE_HEADER).toUInt();
+    searchDialog->ui->guidScopeHeaderRadioButton->setChecked(mode <= SEARCH_MODE_HEADER);
+    searchDialog->ui->guidScopeBodyRadioButton->setChecked(mode == SEARCH_MODE_BODY);
+    searchDialog->ui->guidScopeFullRadioButton->setChecked(mode >= SEARCH_MODE_ALL);
+    mode = settings.value("searchDialog/textScopeMode", SEARCH_MODE_ALL).toUInt();
+    searchDialog->ui->textScopeHeaderRadioButton->setChecked(mode <= SEARCH_MODE_HEADER);
+    searchDialog->ui->textScopeBodyRadioButton->setChecked(mode == SEARCH_MODE_BODY);
+    searchDialog->ui->textScopeFullRadioButton->setChecked(mode >= SEARCH_MODE_ALL);
+    searchDialog->ui->textUnicodeCheckBox->setChecked(settings.value("searchDialog/textUnicode", true).toBool());
+    searchDialog->ui->textCaseSensitiveCheckBox->setChecked(settings.value("searchDialog/textCaseSensitive", false).toBool());
+
     if (searchDialog->exec() != QDialog::Accepted)
         return;
     
+    settings.setValue("searchDialog/geometry", searchDialog->saveGeometry());
+    settings.setValue("searchDialog/currentScopeMode", searchDialog->ui->tabWidget->currentIndex());
+    if (searchDialog->ui->hexScopeHeaderRadioButton->isChecked())
+        mode = SEARCH_MODE_HEADER;
+    else if (searchDialog->ui->hexScopeBodyRadioButton->isChecked())
+        mode = SEARCH_MODE_BODY;
+    else
+        mode = SEARCH_MODE_ALL;
+    settings.setValue("searchDialog/hexScopeMode", mode);
+    if (searchDialog->ui->guidScopeHeaderRadioButton->isChecked())
+        mode = SEARCH_MODE_HEADER;
+    else if (searchDialog->ui->guidScopeBodyRadioButton->isChecked())
+        mode = SEARCH_MODE_BODY;
+    else
+        mode = SEARCH_MODE_ALL;
+    settings.setValue("searchDialog/guidScopeMode", mode);
+    if (searchDialog->ui->textScopeHeaderRadioButton->isChecked())
+        mode = SEARCH_MODE_HEADER;
+    else if (searchDialog->ui->textScopeBodyRadioButton->isChecked())
+        mode = SEARCH_MODE_BODY;
+    else
+        mode = SEARCH_MODE_ALL;
+    settings.setValue("searchDialog/textScopeMode", mode);
+    settings.setValue("searchDialog/textUnicode", searchDialog->ui->textUnicodeCheckBox->isChecked());
+    settings.setValue("searchDialog/textCaseSensitive", searchDialog->ui->textCaseSensitiveCheckBox->isChecked());
+
     int index = searchDialog->ui->tabWidget->currentIndex();
     if (index == 0) { // Hex pattern
         searchDialog->ui->hexEdit->setFocus();
@@ -719,6 +789,105 @@ void UEFITool::saveImageFile()
     
 }
 
+void UEFITool::onDockStateChange(const bool topLevel)
+{
+    QDockWidget* dock = qobject_cast<QDockWidget*>(sender());
+    if (dock)
+        updateDock(dock);
+}
+
+void UEFITool::updateDock(QDockWidget* const dock)
+{
+    if (dock->isHidden())
+        return;
+
+    QWidget *widget = dock->titleBarWidget();
+    QMargins margins = dock->widget()->layout()->contentsMargins();
+    int ref = margins.left();
+    margins.setTop(ref);
+    if (widget) {
+        dock->setTitleBarWidget(nullptr);
+        delete widget;
+    }
+    if (dock->isFloating()) {
+        dock->widget()->layout()->setContentsMargins(margins);
+    }
+    else {
+        QWidget* titleBar = new QWidget(dock);
+        QHBoxLayout* layout = new QHBoxLayout(titleBar);
+        dock->setTitleBarWidget(titleBar);
+        if (!tabifiedDockWidgets(dock).isEmpty()) {
+            layout->setContentsMargins(0, ref, 0, 0);
+            dock->widget()->layout()->setContentsMargins(ref, 0, ref, ref);
+            for (auto tabBar : findChildren<QTabBar*>()) {
+                for (int i = tabBar->count() - 1; i >= 0; i--) {
+                    // hope all docks have different titles
+                    if (dock->windowTitle() == tabBar->tabText(i)) {
+                        QPalette palette = QApplication::palette();
+                        tabBar->setTabTextColor(i, !dock->isEnabled()
+                            ? palette.color(QPalette::Disabled, QPalette::WindowText)
+                                : dock->isVisible()
+                                    ? palette.color(QPalette::Active, QPalette::WindowText)
+                                        : palette.color(QPalette::Inactive, QPalette::WindowText));
+                        return;
+                    }
+                }
+            }
+        }
+        else {
+            layout->setContentsMargins(ref, ref / 2, ref, 0);
+            auto titleLabel = new QLabel(dock->windowTitle());
+            titleLabel->setFont(QApplication::font());
+            layout->addWidget(titleLabel);
+            dock->widget()->layout()->setContentsMargins(ref, ref / 2, ref, ref);
+        }
+    }
+}
+
+void UEFITool::enableDock(QDockWidget* const dock, const bool enable)
+{
+    dock->setEnabled(enable);
+    updateDock(dock);
+}
+
+void UEFITool::resetDocks()
+{
+    selectedHexView.setReadOnly(true);
+
+    addDockWidget(Qt::LeftDockWidgetArea, ui->structureTreeDock);
+    addDockWidget(Qt::RightDockWidgetArea, ui->infoDock);
+    addDockWidget(Qt::BottomDockWidgetArea, ui->parserMessagesDock);
+    tabifyDockWidget(ui->parserMessagesDock, ui->fitDock);
+    tabifyDockWidget(ui->fitDock, ui->securityDock);
+    tabifyDockWidget(ui->securityDock, ui->finderMessagesDock);
+    tabifyDockWidget(ui->finderMessagesDock, ui->builderMessagesDock);
+    ui->parserMessagesDock->raise();
+    tabifyDockWidget(ui->infoDock, ui->hexViewDock);
+    ui->infoDock->raise();
+
+    QSize mainSize = size();
+    int totalWidth = mainSize.width();
+    int leftWidth = totalWidth * 2 / 3;
+    resizeDocks({ ui->structureTreeDock, ui->infoDock },
+        { leftWidth, totalWidth - leftWidth }, Qt::Horizontal);
+
+    int totalHeight = mainSize.height();
+    int topHeight = totalHeight * 4 / 5;
+    resizeDocks({ ui->structureTreeDock, ui->parserMessagesDock },
+        { topHeight, totalHeight - topHeight }, Qt::Vertical);
+
+    QMargins margins = ui->structureTreeWidgetContents->layout()->contentsMargins();
+
+    for (auto dock : findChildren<QDockWidget*>()) {
+        dock->setContentsMargins(0, 0, 0, 0);
+        dock->layout()->setContentsMargins(0, 0, 0, 0);
+        dock->widget()->setContentsMargins(0, 0, 0, 0);
+        dock->widget()->layout()->setContentsMargins(margins);
+        dock->setWindowFlags(dock->windowFlags() | Qt::WindowTitleHint);
+        updateDock(dock);
+    }
+}
+
 void UEFITool::openImageFile()
 {
     QString path = QFileDialog::getOpenFileName(this, tr("Open BIOS image file"), openImageDir, tr("BIOS image files (*.rom *.bin *.cap *.scap *.bio *.fd *.wph *.dec);;All files (*)"));
@@ -782,6 +951,7 @@ void UEFITool::openImageFile(QString path)
         ui->statusBar->showMessage(tr("Opened: %1").arg(fileInfo.fileName()));
     }
     ffsParser->outputInfo();
+    enableDock(ui->structureTreeDock, true);
     
     // Enable or disable FIT tab
     showFitTable();
@@ -820,24 +990,29 @@ void UEFITool::openImageFile(QString path)
 
     // Update menu
     updateRecentFilesMenu(currentPath);
+
+    QModelIndex root = model->index(0, 0, QModelIndex());
+    ui->structureTreeView->selectionModel()->select(root, QItemSelectionModel::Select | QItemSelectionModel::Rows | QItemSelectionModel::Clear);
 }
 
 void UEFITool::enableMessagesCopyActions(QListWidgetItem* item)
 {
     ui->menuMessageActions->setEnabled(item != NULL);
     ui->actionMessagesCopy->setEnabled(item != NULL);
-    ui->actionMessagesCopyAll->setEnabled(item != NULL);
-    ui->actionMessagesClear->setEnabled(item != NULL);
+    ui->actionMessagesCopyAll->setEnabled(item->listWidget()->count() > 0);
+    ui->actionMessagesClear->setEnabled(item->listWidget()->count() > 0);
 }
 
 void UEFITool::copyMessage()
 {
     clipboard->clear();
-    if (ui->messagesTabWidget->currentIndex() == TAB_PARSER) // Parser tab
+
+    int tab = property(propTab()).toInt();
+    if (tab == TAB_PARSER) // Parser tab
         clipboard->setText(ui->parserMessagesListWidget->currentItem()->text());
-    else if (ui->messagesTabWidget->currentIndex() == TAB_SEARCH) // Search tab
+    else if (tab == TAB_SEARCH) // Search tab
         clipboard->setText(ui->finderMessagesListWidget->currentItem()->text());
-    else if (ui->messagesTabWidget->currentIndex() == TAB_BUILDER) // Builder tab
+    else if (tab == TAB_BUILDER) // Builder tab
         clipboard->setText(ui->builderMessagesListWidget->currentItem()->text());
 }
 
@@ -845,17 +1020,19 @@ void UEFITool::copyAllMessages()
 {
     QString text;
     clipboard->clear();
-    if (ui->messagesTabWidget->currentIndex() == TAB_PARSER) { // Parser tab
+
+    int tab = property(propTab()).toInt();
+    if (tab == TAB_PARSER) { // Parser tab
         for (INT32 i = 0; i < ui->parserMessagesListWidget->count(); i++)
             text.append(ui->parserMessagesListWidget->item(i)->text()).append("\n");
         clipboard->setText(text);
     }
-    else if (ui->messagesTabWidget->currentIndex() == TAB_SEARCH) {  // Search tab
+    else if (tab == TAB_SEARCH) {  // Search tab
         for (INT32 i = 0; i < ui->finderMessagesListWidget->count(); i++)
             text.append(ui->finderMessagesListWidget->item(i)->text()).append("\n");
         clipboard->setText(text);
     }
-    else if (ui->messagesTabWidget->currentIndex() == TAB_BUILDER) {  // Builder tab
+    else if (tab == TAB_BUILDER) {  // Builder tab
         for (INT32 i = 0; i < ui->builderMessagesListWidget->count(); i++)
             text.append(ui->builderMessagesListWidget->item(i)->text()).append("\n");
         clipboard->setText(text);
@@ -864,15 +1041,16 @@ void UEFITool::copyAllMessages()
 
 void UEFITool::clearMessages()
 {
-    if (ui->messagesTabWidget->currentIndex() == TAB_PARSER) { // Parser tab
+    int tab = property(propTab()).toInt();
+    if (tab == TAB_PARSER) { // Parser tab
         if (ffsParser) ffsParser->clearMessages();
         ui->parserMessagesListWidget->clear();
     }
-    else if (ui->messagesTabWidget->currentIndex() == TAB_SEARCH) {  // Search tab
+    else if (tab == TAB_SEARCH) {  // Search tab
         if (ffsFinder) ffsFinder->clearMessages();
         ui->finderMessagesListWidget->clear();
     }
-    else if (ui->messagesTabWidget->currentIndex() == TAB_BUILDER) {  // Builder tab
+    else if (tab == TAB_BUILDER) {  // Builder tab
         if (ffsBuilder) ffsBuilder->clearMessages();
         ui->builderMessagesListWidget->clear();
     }
@@ -932,7 +1110,8 @@ void UEFITool::showParserMessages()
         ui->parserMessagesListWidget->addItem(item);
     }
         
-    ui->messagesTabWidget->setCurrentIndex(TAB_PARSER);
+    enableDock(ui->parserMessagesDock, true);
+    ui->parserMessagesDock->raise();
     ui->parserMessagesListWidget->scrollToBottom();
 }
 
@@ -950,8 +1129,8 @@ void UEFITool::showFinderMessages()
         ui->finderMessagesListWidget->addItem(item);
     }
     
-    ui->messagesTabWidget->setTabEnabled(TAB_SEARCH, true);
-    ui->messagesTabWidget->setCurrentIndex(TAB_SEARCH);
+    enableDock(ui->finderMessagesDock, true);
+    ui->finderMessagesDock->raise();
     ui->finderMessagesListWidget->scrollToBottom();
 }
 
@@ -969,8 +1148,8 @@ void UEFITool::showBuilderMessages()
         ui->builderMessagesListWidget->addItem(item);
     }
     
-    ui->messagesTabWidget->setTabEnabled(TAB_BUILDER, true);
-    ui->messagesTabWidget->setCurrentIndex(TAB_BUILDER);
+    enableDock(ui->builderMessagesDock, true);
+    ui->builderMessagesDock->raise();
     ui->builderMessagesListWidget->scrollToBottom();
 }
 
@@ -996,34 +1175,52 @@ void UEFITool::scrollTreeView(QTableWidgetItem* item)
 
 void UEFITool::contextMenuEvent(QContextMenuEvent* event)
 {
-    // The checks involving underMouse do not work well enough on macOS, and result in right-click sometimes
-    // not showing any context menu at all. Most likely it is a bug in Qt, which does not affect other systems.
-    // For this reason we reimplement this manually.
-    if (ui->parserMessagesListWidget->rect().contains(ui->parserMessagesListWidget->mapFromGlobal(event->globalPos())) ||
-        ui->finderMessagesListWidget->rect().contains(ui->finderMessagesListWidget->mapFromGlobal(event->globalPos())) ||
-        ui->builderMessagesListWidget->rect().contains(ui->builderMessagesListWidget->mapFromGlobal(event->globalPos()))) {
-        ui->menuMessageActions->exec(event->globalPos());
-        return;
+    QPoint gp = event->globalPos();
+    for (QListWidget* list : { ui->parserMessagesListWidget, ui->finderMessagesListWidget, ui->builderMessagesListWidget}) {
+        // The checks involving underMouse do not work well enough on macOS, and result in right-click sometimes
+        // not showing any context menu at all. Most likely it is a bug in Qt, which does not affect other systems.
+        // For this reason we reimplement this manually.
+        if (list->rect().contains(list->mapFromGlobal(gp))) {
+            int tab = list->property(propTab()).toInt();
+            setProperty(propTab(), QVariant::fromValue(tab));
+            QListWidgetItem* item = list->itemAt(list->mapFromGlobal(gp));
+            if (item)
+                enableMessagesCopyActions(item);
+            ui->menuMessageActions->exec(gp);
+            setProperty(propTab(), -1);
+            break;
+        }
     }
     
-    
-    if (!ui->structureTreeView->rect().contains(ui->structureTreeView->mapFromGlobal(event->globalPos())))
-        return;
-    
     QPoint pt = event->pos();
+    if (!ui->structureTreeView->rect().contains(ui->structureTreeView->mapFromGlobal(gp))) {
+        QWidget* widget = childAt(pt);
+        while (widget) {
+            if (qobject_cast<QDockWidget*>(widget))
+                return;
+            widget = widget->parentWidget();
+        }
+        QMenu* menu = this->createPopupMenu();
+        if (menu) {
+            menu->exec(gp);
+            menu->deleteLater();
+        }
+    }
+    
     QModelIndex index = ui->structureTreeView->indexAt(ui->structureTreeView->viewport()->mapFrom(this, pt));
     if (!index.isValid()) {
         return;
     }
     
+    QMenu* menu = nullptr;
     switch (model->type(index)) {
-        case Types::Capsule:        ui->menuCapsuleActions->exec(event->globalPos());      break;
-        case Types::Image:          ui->menuImageActions->exec(event->globalPos());        break;
-        case Types::Region:         ui->menuRegionActions->exec(event->globalPos());       break;
-        case Types::Padding:        ui->menuPaddingActions->exec(event->globalPos());      break;
-        case Types::Volume:         ui->menuVolumeActions->exec(event->globalPos());       break;
-        case Types::File:           ui->menuFileActions->exec(event->globalPos());         break;
-        case Types::Section:        ui->menuSectionActions->exec(event->globalPos());      break;
+        case Types::Capsule:        menu = ui->menuCapsuleActions;                         break;
+        case Types::Image:          menu = ui->menuImageActions;                           break;
+        case Types::Region:         menu = ui->menuRegionActions;                          break;
+        case Types::Padding:        menu = ui->menuPaddingActions;                         break;
+        case Types::Volume:         menu = ui->menuVolumeActions;                          break;
+        case Types::File:           menu = ui->menuFileActions;                            break;
+        case Types::Section:        menu = ui->menuSectionActions;                         break;
         case Types::VssStore:
         case Types::Vss2Store:
         case Types::FdcStore:
@@ -1037,34 +1234,23 @@ void UEFITool::contextMenuEvent(QContextMenuEvent* event)
         case Types::CmdbStore:
         case Types::FptStore:
         case Types::CpdStore:
-        case Types::BpdtStore:      ui->menuStoreActions->exec(event->globalPos());        break;
+        case Types::BpdtStore:      menu = ui->menuStoreActions;                           break;
         case Types::FreeSpace:      break; // No menu needed for FreeSpace item
-        default:                    ui->menuEntryActions->exec(event->globalPos());        break;
+        default:                    menu = ui->menuEntryActions;                           break;
+    }
+
+    if (menu) {
+        QList<QAction*> actions = menu->actions();
+        QAction s = QAction(nullptr);
+        s.setSeparator(true);
+        QMenu::exec(
+            actions << &s << ui->actionExpandRecursively << ui->actionCollapseRecursively, gp);
     }
 }
 
 void UEFITool::readSettings()
 {
     QSettings settings(this);
-    restoreGeometry(settings.value("mainWindow/geometry").toByteArray());
-    restoreState(settings.value("mainWindow/windowState").toByteArray());
-    QList<int> horList, vertList;
-    horList.append(settings.value("mainWindow/treeWidth", 600).toInt());
-    horList.append(settings.value("mainWindow/infoWidth", 180).toInt());
-    vertList.append(settings.value("mainWindow/treeHeight", 400).toInt());
-    vertList.append(settings.value("mainWindow/messageHeight", 180).toInt());
-    ui->infoSplitter->setSizes(horList);
-    ui->messagesSplitter->setSizes(vertList);
-    ui->structureTreeView->setColumnWidth(0, settings.value("tree/columnWidth0", ui->structureTreeView->columnWidth(0)).toInt());
-    ui->structureTreeView->setColumnWidth(1, settings.value("tree/columnWidth1", ui->structureTreeView->columnWidth(1)).toInt());
-    ui->structureTreeView->setColumnWidth(2, settings.value("tree/columnWidth2", ui->structureTreeView->columnWidth(2)).toInt());
-    ui->structureTreeView->setColumnWidth(3, settings.value("tree/columnWidth3", ui->structureTreeView->columnWidth(3)).toInt());
-    markingEnabled = settings.value("tree/markingEnabled", true).toBool();
-    ui->actionToggleBootGuardMarking->setChecked(markingEnabled);
-    openImageDir = settings.value("paths/openImageDir", ".").toString();
-    openGuidDatabaseDir = settings.value("paths/openGuidDatabaseDir", ".").toString();
-    extractDir = settings.value("paths/extractDir", ".").toString();
-    recentFiles = settings.value("paths/recentFiles").toStringList();
     
     // Set monospace font
     QString fontName;
@@ -1082,6 +1268,23 @@ void UEFITool::readSettings()
     currentFont = QFont(fontName, fontSize);
     currentFont.setStyleHint(QFont::Monospace);
     QApplication::setFont(currentFont);
+    currentFont.setStretch(QFont::SemiCondensed);
+    selectedHexView.setFont(currentFont);
+
+    resetDocks();
+
+    restoreGeometry(settings.value("mainWindow/geometry").toByteArray());
+    restoreState(settings.value("mainWindow/windowState").toByteArray());
+    ui->structureTreeView->setColumnWidth(0, settings.value("tree/columnWidth0", ui->structureTreeView->columnWidth(0)).toInt());
+    ui->structureTreeView->setColumnWidth(1, settings.value("tree/columnWidth1", ui->structureTreeView->columnWidth(1)).toInt());
+    ui->structureTreeView->setColumnWidth(2, settings.value("tree/columnWidth2", ui->structureTreeView->columnWidth(2)).toInt());
+    ui->structureTreeView->setColumnWidth(3, settings.value("tree/columnWidth3", ui->structureTreeView->columnWidth(3)).toInt());
+    markingEnabled = settings.value("tree/markingEnabled", true).toBool();
+    ui->actionToggleBootGuardMarking->setChecked(markingEnabled);
+    openImageDir = settings.value("paths/openImageDir", ".").toString();
+    openGuidDatabaseDir = settings.value("paths/openGuidDatabaseDir", ".").toString();
+    extractDir = settings.value("paths/extractDir", ".").toString();
+    recentFiles = settings.value("paths/recentFiles").toStringList();
 }
 
 void UEFITool::writeSettings()
@@ -1089,10 +1292,6 @@ void UEFITool::writeSettings()
     QSettings settings(this);
     settings.setValue("mainWindow/geometry", saveGeometry());
     settings.setValue("mainWindow/windowState", saveState());
-    settings.setValue("mainWindow/treeWidth", ui->structureGroupBox->width());
-    settings.setValue("mainWindow/infoWidth", ui->infoGroupBox->width());
-    settings.setValue("mainWindow/treeHeight", ui->structureGroupBox->height());
-    settings.setValue("mainWindow/messageHeight", ui->messagesTabWidget->height());
     settings.setValue("tree/columnWidth0", ui->structureTreeView->columnWidth(0));
     settings.setValue("tree/columnWidth1", ui->structureTreeView->columnWidth(1));
     settings.setValue("tree/columnWidth2", ui->structureTreeView->columnWidth(2));
@@ -1111,12 +1310,12 @@ void UEFITool::showFitTable()
     std::vector<std::pair<std::vector<UString>, UModelIndex> > fitTable = ffsParser->getFitTable();
     if (fitTable.empty()) {
         // Disable FIT tab
-        ui->messagesTabWidget->setTabEnabled(TAB_FIT, false);
+        enableDock(ui->fitDock, false);
         return;
     }
     
     // Enable FIT tab
-    ui->messagesTabWidget->setTabEnabled(TAB_FIT, true);
+    enableDock(ui->fitDock, true);
     
     // Set up the FIT table
     ui->fitTableWidget->clear();
@@ -1139,7 +1338,7 @@ void UEFITool::showFitTable()
     
     ui->fitTableWidget->resizeColumnsToContents();
     ui->fitTableWidget->resizeRowsToContents();
-    ui->messagesTabWidget->setCurrentIndex(TAB_FIT);
+    ui->fitDock->raise();
 }
 
 void UEFITool::showSecurityInfo()
@@ -1147,23 +1346,13 @@ void UEFITool::showSecurityInfo()
     // Get security info
     UString secInfo = ffsParser->getSecurityInfo();
     if (secInfo.isEmpty()) {
-        ui->messagesTabWidget->setTabEnabled(TAB_SECURITY, false);
+        enableDock(ui->securityDock, false);
         return;
     }
     
-    ui->messagesTabWidget->setTabEnabled(TAB_SECURITY, true);
+    enableDock(ui->securityDock, true);
     ui->securityEdit->setPlainText(secInfo);
-    ui->messagesTabWidget->setCurrentIndex(TAB_SECURITY);
-}
-
-void UEFITool::currentTabChanged(int index)
-{
-    U_UNUSED_PARAMETER(index);
-    
-    ui->menuMessageActions->setEnabled(false);
-    ui->actionMessagesCopy->setEnabled(false);
-    ui->actionMessagesCopyAll->setEnabled(false);
-    ui->actionMessagesClear->setEnabled(false);
+    ui->securityDock->raise();
 }
 
 void UEFITool::loadGuidDatabase()
@@ -1235,7 +1424,7 @@ void UEFITool::copyItemName()
     clipboard->setText(model->name(index));
 }
 
-void UEFITool::expandWholeSection()
+void UEFITool::expandRecursively()
 {
     QModelIndex index = ui->structureTreeView->selectionModel()->currentIndex();
     if (!index.isValid())
@@ -1245,7 +1434,7 @@ void UEFITool::expandWholeSection()
     recursivelyUpdateExpandedState(index, true);
 }
 
-void UEFITool::collapseWholeSection()
+void UEFITool::collapseRecursively()
 {
     QModelIndex index = ui->structureTreeView->selectionModel()->currentIndex();
     if (!index.isValid())

--- a/UEFITool/uefitool.h
+++ b/UEFITool/uefitool.h
@@ -175,6 +175,7 @@ private:
     GoToBaseDialog* goToBaseDialog;
     GoToAddressDialog* goToAddressDialog;
     QClipboard* clipboard;
+    QWidget* contextEventWidget;
     QStringList recentFiles;
     QList<QAction*> recentFileActions;
     QHexView selectedHexView;
@@ -208,16 +209,6 @@ private:
     void doSha384(QByteArray data);
     void doSha512(QByteArray data);
     void doSm3(QByteArray data);
-
-    const char* propTab() { return "TAB_INDEX"; }
-    
-    enum {
-        TAB_PARSER,
-        TAB_FIT,
-        TAB_SECURITY,
-        TAB_SEARCH,
-        TAB_BUILDER
-    };
 };
 
 #endif // UEFITOOL_H

--- a/UEFITool/uefitool.h
+++ b/UEFITool/uefitool.h
@@ -115,10 +115,14 @@ private slots:
     void clearMessages();
 
     void copyItemName();
-    void expandWholeSection();
-    void collapseWholeSection();
+    void expandRecursively();
+    void collapseRecursively();
 
     void toggleBootGuardMarking(bool enabled);
+    void onDockStateChange(const bool state);
+    void updateDock(QDockWidget* const dock);
+    void enableDock(QDockWidget* const dock, const bool enable);
+    void resetDocks();
 
     void about();
     void aboutQt();
@@ -132,8 +136,6 @@ private slots:
     void exportDiscoveredGuids();
 
     void generateReport();
-
-    void currentTabChanged(int index);
 
     void hashCrc32();
     void hashSha1();
@@ -175,6 +177,7 @@ private:
     QClipboard* clipboard;
     QStringList recentFiles;
     QList<QAction*> recentFileActions;
+    QHexView selectedHexView;
     QString currentDir;
     QString currentPath;
     QString currentProgramPath;
@@ -205,6 +208,8 @@ private:
     void doSha384(QByteArray data);
     void doSha512(QByteArray data);
     void doSm3(QByteArray data);
+
+    const char* propTab() { return "TAB_INDEX"; }
     
     enum {
         TAB_PARSER,

--- a/UEFITool/uefitool.h
+++ b/UEFITool/uefitool.h
@@ -35,6 +35,7 @@
 #include <QStyleFactory>
 #include <QString>
 #include <QTableWidget>
+#include <QTimer>
 #include <QTreeView>
 #include <QUrl>
 
@@ -52,6 +53,7 @@
 #include "gotoaddressdialog.h"
 #include "hexviewdialog.h"
 #include "ffsfinder.h"
+
 
 namespace Ui {
     class UEFITool;
@@ -120,9 +122,10 @@ private slots:
 
     void toggleBootGuardMarking(bool enabled);
     void onDockStateChange(const bool state);
-    void updateDock(QDockWidget* const dock);
     void enableDock(QDockWidget* const dock, const bool enable);
     void resetDocks();
+    void updateDock(QDockWidget* const dock);
+    void checkAndUpdateDocks();
 
     void about();
     void aboutQt();
@@ -178,6 +181,7 @@ private:
     QWidget* contextEventWidget;
     QStringList recentFiles;
     QList<QAction*> recentFileActions;
+    QTimer dockTimer;
     QHexView selectedHexView;
     QString currentDir;
     QString currentPath;
@@ -195,6 +199,7 @@ private:
     void contextMenuEvent(QContextMenuEvent* event);
     void updateRecentFilesMenu(const QString& fileName = QString());
     void readSettings();
+    bool checkDock(QDockWidget* const dock);
     void showParserMessages();
     void showFinderMessages();
     void showFitTable();

--- a/UEFITool/uefitool.ui
+++ b/UEFITool/uefitool.ui
@@ -24,285 +24,241 @@
   </property>
   <widget class="QWidget" name="centralWidget">
    <property name="sizePolicy">
-    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
      <horstretch>0</horstretch>
      <verstretch>0</verstretch>
     </sizepolicy>
    </property>
-   <layout class="QHBoxLayout" name="horizontalLayout1">
-    <property name="spacing">
-     <number>0</number>
-    </property>
-    <property name="leftMargin">
-     <number>5</number>
-    </property>
-    <property name="topMargin">
-     <number>5</number>
-    </property>
-    <property name="rightMargin">
-     <number>5</number>
-    </property>
-    <property name="bottomMargin">
-     <number>5</number>
-    </property>
-    <item>
-     <widget class="QSplitter" name="messagesSplitter">
-      <property name="orientation">
-       <enum>Qt::Vertical</enum>
-      </property>
-      <widget class="QSplitter" name="infoSplitter">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+   <property name="minimumSize">
+    <size>
+     <width>0</width>
+     <height>0</height>
+    </size>
+   </property>
+   <property name="maximumSize">
+    <size>
+     <width>0</width>
+     <height>16777215</height>
+    </size>
+   </property>
+   <property name="focusPolicy">
+    <enum>Qt::FocusPolicy::NoFocus</enum>
+   </property>
+  </widget>
+  <widget class="QDockWidget" name="structureTreeDock">
+   <property name="floating">
+    <bool>false</bool>
+   </property>
+   <property name="features">
+    <set>QDockWidget::DockWidgetFeature::DockWidgetFloatable|QDockWidget::DockWidgetFeature::DockWidgetMovable</set>
+   </property>
+   <property name="allowedAreas">
+    <set>Qt::DockWidgetArea::LeftDockWidgetArea|Qt::DockWidgetArea::RightDockWidgetArea|Qt::DockWidgetArea::TopDockWidgetArea</set>
+   </property>
+   <property name="windowTitle">
+    <string>Structure</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>1</number>
+   </attribute>
+   <widget class="QWidget" name="structureTreeWidgetContents">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QTreeView" name="structureTreeView">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <widget class="QGroupBox" name="structureGroupBox">
-        <property name="title">
-         <string>Structure</string>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout2">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="leftMargin">
-          <number>5</number>
-         </property>
-         <property name="topMargin">
-          <number>5</number>
-         </property>
-         <property name="rightMargin">
-          <number>5</number>
-         </property>
-         <property name="bottomMargin">
-          <number>5</number>
-         </property>
-         <item>
-          <widget class="QTreeView" name="structureTreeView">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="indentation">
-            <number>10</number>
-           </property>
-           <property name="headerHidden">
-            <bool>false</bool>
-           </property>
-           <attribute name="headerCascadingSectionResizes">
-            <bool>true</bool>
-           </attribute>
-           <attribute name="headerDefaultSectionSize">
-            <number>200</number>
-           </attribute>
-           <attribute name="headerStretchLastSection">
-            <bool>true</bool>
-           </attribute>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QGroupBox" name="infoGroupBox">
-        <property name="title">
-         <string>Information</string>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout3">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="leftMargin">
-          <number>5</number>
-         </property>
-         <property name="topMargin">
-          <number>5</number>
-         </property>
-         <property name="rightMargin">
-          <number>5</number>
-         </property>
-         <property name="bottomMargin">
-          <number>5</number>
-         </property>
-         <item>
-          <widget class="QPlainTextEdit" name="infoEdit">
-           <property name="acceptDrops">
-            <bool>false</bool>
-           </property>
-           <property name="undoRedoEnabled">
-            <bool>false</bool>
-           </property>
-           <property name="readOnly">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
+       <property name="indentation">
+        <number>10</number>
+       </property>
+       <property name="headerHidden">
+        <bool>false</bool>
+       </property>
+       <attribute name="headerCascadingSectionResizes">
+        <bool>true</bool>
+       </attribute>
+       <attribute name="headerDefaultSectionSize">
+        <number>200</number>
+       </attribute>
+       <attribute name="headerStretchLastSection">
+        <bool>true</bool>
+       </attribute>
       </widget>
-      <widget class="QTabWidget" name="messagesTabWidget">
-       <property name="enabled">
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QDockWidget" name="infoDock">
+   <property name="features">
+    <set>QDockWidget::DockWidgetFeature::DockWidgetClosable|QDockWidget::DockWidgetFeature::DockWidgetFloatable|QDockWidget::DockWidgetFeature::DockWidgetMovable</set>
+   </property>
+   <property name="allowedAreas">
+    <set>Qt::DockWidgetArea::AllDockWidgetAreas</set>
+   </property>
+   <property name="windowTitle">
+    <string>Information</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>1</number>
+   </attribute>
+   <widget class="QWidget" name="infoWidgetContents">
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <widget class="QPlainTextEdit" name="infoEdit">
+       <property name="acceptDrops">
+        <bool>false</bool>
+       </property>
+       <property name="undoRedoEnabled">
+        <bool>false</bool>
+       </property>
+       <property name="readOnly">
         <bool>true</bool>
        </property>
-       <property name="currentIndex">
-        <number>0</number>
-       </property>
-       <widget class="QWidget" name="parserTab">
-        <attribute name="title">
-         <string>Parser</string>
-        </attribute>
-        <layout class="QHBoxLayout" name="horizontalLayout4">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="leftMargin">
-          <number>5</number>
-         </property>
-         <property name="topMargin">
-          <number>5</number>
-         </property>
-         <property name="rightMargin">
-          <number>5</number>
-         </property>
-         <property name="bottomMargin">
-          <number>5</number>
-         </property>
-         <item>
-          <widget class="QListWidget" name="parserMessagesListWidget">
-           <property name="mouseTracking">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="fitTab">
-        <attribute name="title">
-         <string>FIT</string>
-        </attribute>
-        <layout class="QHBoxLayout" name="horizontalLayout5">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="leftMargin">
-          <number>5</number>
-         </property>
-         <property name="topMargin">
-          <number>5</number>
-         </property>
-         <property name="rightMargin">
-          <number>5</number>
-         </property>
-         <property name="bottomMargin">
-          <number>5</number>
-         </property>
-         <item>
-          <widget class="QSplitter" name="splitter">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <widget class="QTableWidget" name="fitTableWidget"/>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="securityTab">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <attribute name="title">
-         <string>Security</string>
-        </attribute>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="leftMargin">
-          <number>5</number>
-         </property>
-         <property name="topMargin">
-          <number>5</number>
-         </property>
-         <property name="rightMargin">
-          <number>5</number>
-         </property>
-         <property name="bottomMargin">
-          <number>5</number>
-         </property>
-         <item>
-          <widget class="QPlainTextEdit" name="securityEdit">
-           <property name="acceptDrops">
-            <bool>false</bool>
-           </property>
-           <property name="undoRedoEnabled">
-            <bool>false</bool>
-           </property>
-           <property name="readOnly">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="finderTab">
-        <attribute name="title">
-         <string>Search</string>
-        </attribute>
-        <layout class="QHBoxLayout" name="horizontalLayout6">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="leftMargin">
-          <number>5</number>
-         </property>
-         <property name="topMargin">
-          <number>5</number>
-         </property>
-         <property name="rightMargin">
-          <number>5</number>
-         </property>
-         <property name="bottomMargin">
-          <number>5</number>
-         </property>
-         <item>
-          <widget class="QListWidget" name="finderMessagesListWidget">
-           <property name="mouseTracking">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="builderTab">
-        <attribute name="title">
-         <string>Builder</string>
-        </attribute>
-        <layout class="QHBoxLayout" name="horizontalLayout7">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="leftMargin">
-          <number>5</number>
-         </property>
-         <property name="topMargin">
-          <number>5</number>
-         </property>
-         <property name="rightMargin">
-          <number>5</number>
-         </property>
-         <property name="bottomMargin">
-          <number>5</number>
-         </property>
-         <item>
-          <widget class="QListWidget" name="builderMessagesListWidget">
-           <property name="mouseTracking">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
       </widget>
-     </widget>
-    </item>
-   </layout>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QDockWidget" name="parserMessagesDock">
+   <property name="features">
+    <set>QDockWidget::DockWidgetFeature::DockWidgetClosable|QDockWidget::DockWidgetFeature::DockWidgetFloatable|QDockWidget::DockWidgetFeature::DockWidgetMovable</set>
+   </property>
+   <property name="allowedAreas">
+    <set>Qt::DockWidgetArea::AllDockWidgetAreas</set>
+   </property>
+   <property name="windowTitle">
+    <string>Parser</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>8</number>
+   </attribute>
+   <widget class="QWidget" name="parserMessagesWidgetContents">
+    <layout class="QVBoxLayout" name="verticalLayout_3">
+     <item>
+      <widget class="QListWidget" name="parserMessagesListWidget">
+       <property name="mouseTracking">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QDockWidget" name="fitDock">
+   <property name="features">
+    <set>QDockWidget::DockWidgetFeature::DockWidgetClosable|QDockWidget::DockWidgetFeature::DockWidgetFloatable|QDockWidget::DockWidgetFeature::DockWidgetMovable</set>
+   </property>
+   <property name="allowedAreas">
+    <set>Qt::DockWidgetArea::AllDockWidgetAreas</set>
+   </property>
+   <property name="windowTitle">
+    <string>FIT</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>8</number>
+   </attribute>
+   <widget class="QWidget" name="fitWidgetContents">
+    <layout class="QVBoxLayout" name="verticalLayout_4">
+     <item>
+      <widget class="QTableWidget" name="fitTableWidget"/>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QDockWidget" name="securityDock">
+   <property name="features">
+    <set>QDockWidget::DockWidgetFeature::DockWidgetClosable|QDockWidget::DockWidgetFeature::DockWidgetFloatable|QDockWidget::DockWidgetFeature::DockWidgetMovable</set>
+   </property>
+   <property name="allowedAreas">
+    <set>Qt::DockWidgetArea::AllDockWidgetAreas</set>
+   </property>
+   <property name="windowTitle">
+    <string>Security</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>8</number>
+   </attribute>
+   <widget class="QWidget" name="securityWidgetContents">
+    <layout class="QVBoxLayout" name="verticalLayout_5">
+     <item>
+      <widget class="QPlainTextEdit" name="securityEdit">
+       <property name="acceptDrops">
+        <bool>false</bool>
+       </property>
+       <property name="undoRedoEnabled">
+        <bool>false</bool>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QDockWidget" name="finderMessagesDock">
+   <property name="features">
+    <set>QDockWidget::DockWidgetFeature::DockWidgetClosable|QDockWidget::DockWidgetFeature::DockWidgetFloatable|QDockWidget::DockWidgetFeature::DockWidgetMovable</set>
+   </property>
+   <property name="allowedAreas">
+    <set>Qt::DockWidgetArea::AllDockWidgetAreas</set>
+   </property>
+   <property name="windowTitle">
+    <string>Search</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>8</number>
+   </attribute>
+   <widget class="QWidget" name="finderMessagesWidgetContents">
+    <layout class="QVBoxLayout" name="verticalLayout_6">
+     <item>
+      <widget class="QListWidget" name="finderMessagesListWidget">
+       <property name="mouseTracking">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QDockWidget" name="builderMessagesDock">
+   <property name="features">
+    <set>QDockWidget::DockWidgetFeature::DockWidgetClosable|QDockWidget::DockWidgetFeature::DockWidgetFloatable|QDockWidget::DockWidgetFeature::DockWidgetMovable</set>
+   </property>
+   <property name="allowedAreas">
+    <set>Qt::DockWidgetArea::BottomDockWidgetArea</set>
+   </property>
+   <property name="windowTitle">
+    <string>Builder</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>8</number>
+   </attribute>
+   <widget class="QWidget" name="builderMessagesWidgetContents">
+    <layout class="QVBoxLayout" name="verticalLayout_7">
+     <item>
+      <widget class="QListWidget" name="builderMessagesListWidget">
+       <property name="mouseTracking">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QDockWidget" name="hexViewDock">
+   <property name="windowTitle">
+    <string>Hex view</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>1</number>
+   </attribute>
+   <widget class="QWidget" name="hexViewWidgetContents">
+    <layout class="QVBoxLayout" name="verticalLayout_8"/>
+   </widget>
   </widget>
   <widget class="QStatusBar" name="statusBar"/>
   <widget class="QMenuBar" name="menuBar">
@@ -360,9 +316,6 @@
      <addaction name="actionExtractBody"/>
      <addaction name="separator"/>
      <addaction name="actionCopyItemName"/>
-     <addaction name="separator"/>
-     <addaction name="actionExpandWholeSection"/>
-     <addaction name="actionCollapseWholeSection"/>
     </widget>
     <widget class="QMenu" name="menuImageActions">
      <property name="title">
@@ -375,9 +328,6 @@
      <addaction name="actionExtract"/>
      <addaction name="separator"/>
      <addaction name="actionCopyItemName"/>
-     <addaction name="separator"/>
-     <addaction name="actionExpandWholeSection"/>
-     <addaction name="actionCollapseWholeSection"/>
     </widget>
     <widget class="QMenu" name="menuRegionActions">
      <property name="title">
@@ -394,9 +344,6 @@
      <addaction name="actionReplace"/>
      <addaction name="separator"/>
      <addaction name="actionCopyItemName"/>
-     <addaction name="separator"/>
-     <addaction name="actionExpandWholeSection"/>
-     <addaction name="actionCollapseWholeSection"/>
     </widget>
     <widget class="QMenu" name="menuPaddingActions">
      <property name="title">
@@ -409,9 +356,6 @@
      <addaction name="actionExtract"/>
      <addaction name="separator"/>
      <addaction name="actionCopyItemName"/>
-     <addaction name="separator"/>
-     <addaction name="actionExpandWholeSection"/>
-     <addaction name="actionCollapseWholeSection"/>
     </widget>
     <widget class="QMenu" name="menuVolumeActions">
      <property name="title">
@@ -436,9 +380,6 @@
      <addaction name="actionReplaceBody"/>
      <addaction name="separator"/>
      <addaction name="actionCopyItemName"/>
-     <addaction name="separator"/>
-     <addaction name="actionExpandWholeSection"/>
-     <addaction name="actionCollapseWholeSection"/>
     </widget>
     <widget class="QMenu" name="menuFileActions">
      <property name="title">
@@ -467,9 +408,6 @@
      <addaction name="actionRemove"/>
      <addaction name="separator"/>
      <addaction name="actionCopyItemName"/>
-     <addaction name="separator"/>
-     <addaction name="actionExpandWholeSection"/>
-     <addaction name="actionCollapseWholeSection"/>
     </widget>
     <widget class="QMenu" name="menuSectionActions">
      <property name="title">
@@ -499,9 +437,6 @@
      <addaction name="actionRemove"/>
      <addaction name="separator"/>
      <addaction name="actionCopyItemName"/>
-     <addaction name="separator"/>
-     <addaction name="actionExpandWholeSection"/>
-     <addaction name="actionCollapseWholeSection"/>
     </widget>
     <widget class="QMenu" name="menuMessageActions">
      <property name="enabled">
@@ -543,9 +478,6 @@
      <addaction name="actionRemove"/>
      <addaction name="separator"/>
      <addaction name="actionCopyItemName"/>
-     <addaction name="separator"/>
-     <addaction name="actionExpandWholeSection"/>
-     <addaction name="actionCollapseWholeSection"/>
      <addaction name="separator"/>
     </widget>
     <widget class="QMenu" name="menuStoreActions">
@@ -615,9 +547,6 @@
      <addaction name="actionReplaceBody"/>
      <addaction name="separator"/>
      <addaction name="actionCopyItemName"/>
-     <addaction name="separator"/>
-     <addaction name="actionExpandWholeSection"/>
-     <addaction name="actionCollapseWholeSection"/>
     </widget>
     <addaction name="actionGoToBase"/>
     <addaction name="actionGoToAddress"/>
@@ -642,6 +571,9 @@
      <string>&amp;View</string>
     </property>
     <addaction name="actionToggleBootGuardMarking"/>
+    <addaction name="separator"/>
+    <addaction name="actionExpandRecursively"/>
+    <addaction name="actionCollapseRecursively"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuAction"/>
@@ -999,23 +931,23 @@
     <string>Ctrl+C</string>
    </property>
   </action>
-  <action name="actionExpandWholeSection">
+  <action name="actionExpandRecursively">
    <property name="enabled">
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>E&amp;xpand whole section</string>
+    <string>E&amp;xpand recursively</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+[</string>
    </property>
   </action>
-  <action name="actionCollapseWholeSection">
+  <action name="actionCollapseRecursively">
    <property name="enabled">
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>C&amp;ollapse whole section</string>
+    <string>C&amp;ollapse recursively</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+]</string>

--- a/UEFITool/uefitool.ui
+++ b/UEFITool/uefitool.ui
@@ -50,7 +50,7 @@
     <bool>false</bool>
    </property>
    <property name="features">
-    <set>QDockWidget::DockWidgetFeature::DockWidgetFloatable|QDockWidget::DockWidgetFeature::DockWidgetMovable</set>
+    <set>QDockWidget::DockWidgetFeature::DockWidgetClosable|QDockWidget::DockWidgetFeature::DockWidgetFloatable|QDockWidget::DockWidgetFeature::DockWidgetMovable</set>
    </property>
    <property name="allowedAreas">
     <set>Qt::DockWidgetArea::LeftDockWidgetArea|Qt::DockWidgetArea::RightDockWidgetArea|Qt::DockWidgetArea::TopDockWidgetArea</set>


### PR DESCRIPTION
…ear files list and expand/collapse tree nodes

I would like to suggest you some changes to the interface:
- replaced fixed UI with docks;
- added hex view dock with header (if exists) highlighting;
- added search dialog settings save and restore;
- small fixes to "clear recently opened files list" and "Expand whole section"/"Collapse whole section" menu events as per https://github.com/LongSoft/UEFITool/issues/437

~~! There is a small problem still not fixed with docks - new UI looks like garbage if settings exist after previous UEFITool with classic UI launches. Before running UEFITool with docks please delete those settings.~~

! In Wayland, docks will not float.

! Because of new hex editing features I've added (but still not published) using existing menu events "hex view"/"hex body view", I don't know, what to do with existing classic "hex view"/"hex body view"; but they are still usable even if hex view dock is visible.

Enjoy!
