### PR TITLE
Improved AMD-specific structures parsing

### DIFF
--- a/common/descriptor.h
+++ b/common/descriptor.h
@@ -201,17 +201,7 @@ typedef struct VSCC_TABLE_ENTRY_ {
 #define AMD_PSP_COMBO_DIRECTORY_HEADER_SIGNATURE    0x50535032  // "2PSP"
 #define AMD_PSP_BHD2_DIRECTORY_HEADER_SIGNATURE     0x44484232  // "2BHD"
 
-#define AMD_EFS_GEN1                                0xFFFFFFFFUL
-
 #define AMD_EMBEDDED_FIRMWARE_OFFSET                0x20000
-
-#define AMD_INVALID_SIZE                            0xFFFFFFFFUL
-
-/* An address can be relative to the image/file start but it can also be the address when
- * the image is mapped at 0xff000000. Used to ensure that we only attempt to read within
- * the limits of the file. */
-#define SPI_ROM_BASE                                0xFF000000UL
-#define FILE_REL_MASK                               (~SPI_ROM_BASE)
 
 typedef enum AMD_ADDR_MODE_ {
     AMD_ADDR_PHYSICAL = 0,	    // Physical address
@@ -269,7 +259,7 @@ typedef enum AMD_FW_TYPE_ {
     AMD_FW_DXIO = 0x42,
     AMD_FW_USB_PHY = 0x44,
     AMD_FW_TOS_SEC_POLICY = 0x45,
-    AMD_FET_BACKUP = 0x46,
+    AMD_EFS_BACKUP = 0x46,
     AMD_FW_DRTM_TA = 0x47,
     AMD_FW_RECOVERYAB_A = 0x48,
     AMD_FW_RECOVERYAB_B = 0x4A,
@@ -364,7 +354,7 @@ typedef struct AMD_EMBEDDED_FIRMWARE_ {
     // Might be a BIOS directory or Combo directory table
     UINT32 BackupPSP_Directory;
     UINT32 Promontory_Firmware;
-    UINT32 Reserved_1[6];
+    UINT32 Reserved_1[7];
 } AMD_EMBEDDED_FIRMWARE;
 
 #define AMD_ADDITIONAL_INFO_V0_DEF \

--- a/common/types.cpp
+++ b/common/types.cpp
@@ -191,13 +191,13 @@ UString itemSubtypeToUString(const UINT8 type, const UINT8 subtype)
         case Types::DirectoryTable:
             if (subtype == Subtypes::PSPDirectory)                 return UString("PSP table");
             if (subtype == Subtypes::ComboDirectory)               return UString("Combo table");
-            if (subtype == Subtypes::BiosDirectory)                return UString("BIOS table");
+            if (subtype == Subtypes::BIOSDirectory)                return UString("BIOS table");
             if (subtype == Subtypes::ISHDirectory)                 return UString("ISH table");
             break;
         case Types::DirectoryTableEntry:
             if (subtype == Subtypes::PSPDirectory)                 return UString("PSP directory");
             if (subtype == Subtypes::ComboDirectory)               return UString("Combo directory");
-            if (subtype == Subtypes::BiosDirectory)                return UString("BIOS directory");
+            if (subtype == Subtypes::BIOSDirectory)                return UString("BIOS directory");
             break;
     }
     

--- a/common/types.h
+++ b/common/types.h
@@ -156,8 +156,9 @@ namespace Subtypes {
     enum DirectorySubtypes {
         PSPDirectory = 155,
         ComboDirectory,
-        BiosDirectory,
+        BIOSDirectory,
         ISHDirectory,
+        AnyDirectory,
     };
     
     enum EvsaEntrySubtypes {


### PR DESCRIPTION
Compared to #443 :
- improved banks detection (but the code is still ugly sometimes);
- directories offsets calculation as for files in physical mode;
- more complete info about items, especially for files;
- enumerating directory table entries for clarity;
- more clear info about item's parents and childs, added bases for each and entry numbers if parent is directory table;
- if a file has several parents then check if some flags and properies values is different, marking such with "*" in info;
- changed "EFT" to "FET", trying to autodetect FET size, more info for FET;
- code refactoring and cleanup.

Tested on ~24 images from different times, but, as usual, much more images needed to explore. In particular, I was never able to find the image with the ISH directory table. If anyone has such images, please, share!

TODOs generally remain the same...