### PR TITLE
Set of patches from fuzzing campaign 

### DIFF
--- a/common/LZMA/LzmaDecompress.c
+++ b/common/LZMA/LzmaDecompress.c
@@ -94,10 +94,9 @@ LzmaGetInfo (
     )
 {
     UINT64 DecodedSize;
-    if(SourceSize <= LZMA_HEADER_SIZE){
+    if (SourceSize <= LZMA_HEADER_SIZE) {
         return U_BUFFER_TOO_SMALL;
     }
-    (void)SourceSize;
 
     DecodedSize = GetDecodedSizeOfBuf((UINT8*)Source);
 

--- a/common/LZMA/LzmaDecompress.c
+++ b/common/LZMA/LzmaDecompress.c
@@ -72,7 +72,7 @@ checking of the validity of the source data. It just retrieves the "Original Siz
 field from the LZMA_HEADER_SIZE beginning bytes of the source data and output it as DestinationSize.
 And ScratchSize is specific to the decompression implementation.
 
-If SourceSize is less than LZMA_HEADER_SIZE, then ASSERT().
+If SourceSize is less than LZMA_HEADER_SIZE, then return U_BUFFER_TOO_SMALL.
 
 @param  Source          The source buffer containing the compressed data.
 @param  SourceSize      The size, bytes, of the source buffer.
@@ -94,7 +94,9 @@ LzmaGetInfo (
     )
 {
     UINT64 DecodedSize;
-    ASSERT(SourceSize >= LZMA_HEADER_SIZE);
+    if(SourceSize <= LZMA_HEADER_SIZE){
+        return U_BUFFER_TOO_SMALL;
+    }
     (void)SourceSize;
 
     DecodedSize = GetDecodedSizeOfBuf((UINT8*)Source);

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -5191,7 +5191,7 @@ make_partition_table_consistent:
                 if (!partitions[i].ptEntry.Offset.HuffmanCompressed
                     && partitions[i].ptEntry.Length >= sizeof(CPD_MANIFEST_HEADER)) {
                     const CPD_MANIFEST_HEADER* manifestHeader = (const CPD_MANIFEST_HEADER*) partition.constData();
-                    if (manifestHeader->HeaderId == ME_MANIFEST_HEADER_ID) {
+                    if (manifestHeader->HeaderId == ME_MANIFEST_HEADER_ID && (manifestHeader->HeaderLength * sizeof(UINT32)) <= partition.size()) {
                         UByteArray header = partition.left(manifestHeader->HeaderLength * sizeof(UINT32));
                         UByteArray body = partition.mid(manifestHeader->HeaderLength * sizeof(UINT32));
                         
@@ -5296,27 +5296,28 @@ USTATUS FfsParser::parseCpdExtensionsArea(const UModelIndex & index, const UINT3
             if (extHeader->Type == CPD_EXT_TYPE_SIGNED_PACKAGE_INFO) {
                 UByteArray header = partition.left(sizeof(CPD_EXT_SIGNED_PACKAGE_INFO));
                 UByteArray data = partition.mid(header.size());
+                if(header.size() >= sizeof(CPD_EXT_SIGNED_PACKAGE_INFO)){
+                    const CPD_EXT_SIGNED_PACKAGE_INFO* infoHeader = (const CPD_EXT_SIGNED_PACKAGE_INFO*)header.constData();
                 
-                const CPD_EXT_SIGNED_PACKAGE_INFO* infoHeader = (const CPD_EXT_SIGNED_PACKAGE_INFO*)header.constData();
-                
-                info = usprintf("Full size: %Xh (%u)\nHeader size: %Xh (%u)\nBody size: %Xh (%u)\nType: %Xh\n"
-                                "Package name: %.4s\nVersion control number: %Xh\nSecurity version number: %Xh\n"
-                                "Usage bitmap: %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
-                                (UINT32)partition.size(), (UINT32)partition.size(),
-                                (UINT32)header.size(), (UINT32)header.size(),
-                                (UINT32)body.size(), (UINT32)body.size(),
-                                infoHeader->ExtensionType,
-                                infoHeader->PackageName,
-                                infoHeader->Vcn,
-                                infoHeader->Svn,
-                                infoHeader->UsageBitmap[0],  infoHeader->UsageBitmap[1],  infoHeader->UsageBitmap[2],  infoHeader->UsageBitmap[3],
-                                infoHeader->UsageBitmap[4],  infoHeader->UsageBitmap[5],  infoHeader->UsageBitmap[6],  infoHeader->UsageBitmap[7],
-                                infoHeader->UsageBitmap[8],  infoHeader->UsageBitmap[9],  infoHeader->UsageBitmap[10], infoHeader->UsageBitmap[11],
-                                infoHeader->UsageBitmap[12], infoHeader->UsageBitmap[13], infoHeader->UsageBitmap[14], infoHeader->UsageBitmap[15]);
-                
-                // Add tree item
-                extIndex = model->addItem(offset + localOffset, Types::CpdExtension, 0, name, UString(), info, header, data, UByteArray(), Fixed, index);
-                parseSignedPackageInfoData(extIndex);
+                    info = usprintf("Full size: %Xh (%u)\nHeader size: %Xh (%u)\nBody size: %Xh (%u)\nType: %Xh\n"
+                                    "Package name: %.4s\nVersion control number: %Xh\nSecurity version number: %Xh\n"
+                                    "Usage bitmap: %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
+                                    (UINT32)partition.size(), (UINT32)partition.size(),
+                                    (UINT32)header.size(), (UINT32)header.size(),
+                                    (UINT32)body.size(), (UINT32)body.size(),
+                                    infoHeader->ExtensionType,
+                                    infoHeader->PackageName,
+                                    infoHeader->Vcn,
+                                    infoHeader->Svn,
+                                    infoHeader->UsageBitmap[0],  infoHeader->UsageBitmap[1],  infoHeader->UsageBitmap[2],  infoHeader->UsageBitmap[3],
+                                    infoHeader->UsageBitmap[4],  infoHeader->UsageBitmap[5],  infoHeader->UsageBitmap[6],  infoHeader->UsageBitmap[7],
+                                    infoHeader->UsageBitmap[8],  infoHeader->UsageBitmap[9],  infoHeader->UsageBitmap[10], infoHeader->UsageBitmap[11],
+                                    infoHeader->UsageBitmap[12], infoHeader->UsageBitmap[13], infoHeader->UsageBitmap[14], infoHeader->UsageBitmap[15]);
+
+                    // Add tree item
+                    extIndex = model->addItem(offset + localOffset, Types::CpdExtension, 0, name, UString(), info, header, data, UByteArray(), Fixed, index);
+                    parseSignedPackageInfoData(extIndex);
+                }
             }
             // Parse IFWI Partition Manifest a bit further
             else if (extHeader->Type == CPD_EXT_TYPE_IFWI_PARTITION_MANIFEST) {

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -2904,6 +2904,10 @@ USTATUS FfsParser::parseGuidedSectionHeader(const UByteArray & section, const UI
         if (certType == WIN_CERT_TYPE_EFI_GUID) {
             additionalInfo += UString("\nCertificate type: UEFI");
             
+            // Sanity check
+            if ((UINT32)section.size() < headerSize + sizeof(WIN_CERTIFICATE_UEFI_GUID))
+                return U_INVALID_SECTION;
+
             // Get certificate GUID
             const WIN_CERTIFICATE_UEFI_GUID* winCertificateUefiGuid = (const WIN_CERTIFICATE_UEFI_GUID*)(section.constData() + headerSize);
             UByteArray certTypeGuid((const char*)&winCertificateUefiGuid->CertType, sizeof(EFI_GUID));

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -2777,7 +2777,7 @@ USTATUS FfsParser::parseGuidedSectionHeader(const UByteArray & section, const UI
         attributes = guidDefinedSectionHeader->Attributes;
     }
     // Check sanity again
-    if ((UINT32)section.size() < headerSize)
+    if ((UINT32)section.size() < headerSize || section.size() < dataOffset)
         return U_INVALID_SECTION;
     
     // Check for special GUIDed sections

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -3432,7 +3432,8 @@ USTATUS FfsParser::parseVersionSectionBody(const UModelIndex & index)
         return U_INVALID_PARAMETER;
     
     // Add info
-    model->addInfo(index, UString("\nVersion string: ") + uFromUcs2(model->body(index).constData()));
+    UByteArray body = model->body(index);
+    model->addInfo(index, UString("\nVersion string: ") + uFromUcs2(body.constData(), body.size()));
     
     return U_SUCCESS;
 }

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -2171,7 +2171,9 @@ USTATUS FfsParser::parseFileHeader(const UByteArray & file, const UINT32 localOf
     
     // Get file body
     UByteArray body = file.mid(header.size());
-    
+    if(body.size() < sizeof(UINT16)){
+        return U_INVALID_FILE;
+    }
     // Check for file tail presence
     UByteArray tail;
     bool msgInvalidTailValue = false;

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -422,8 +422,11 @@ USTATUS FfsParser::parseIntelImage(const UByteArray & intelImage, const UINT32 l
                         index);
                     return U_TRUNCATED_IMAGE;
                 }
-                region.data = intelImage.mid(region.offset, region.length);
-                regions.push_back(region);
+
+                if(intelImage.size() > region.offset){
+                    region.data = intelImage.mid(region.offset, region.length);
+                    regions.push_back(region);
+                }
             }
         }
     }

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -2774,6 +2774,8 @@ USTATUS FfsParser::parseGuidedSectionHeader(const UByteArray & section, const UI
     }
     else { // Normal section
         const EFI_GUID_DEFINED_SECTION* guidDefinedSectionHeader = (const EFI_GUID_DEFINED_SECTION*)(sectionHeader + 1);
+        if ((UINT32)section.size() < sizeof(EFI_COMMON_SECTION_HEADER) + sizeof(EFI_GUID_DEFINED_SECTION))
+            return U_INVALID_SECTION;
         headerSize = sizeof(EFI_COMMON_SECTION_HEADER) + sizeof(EFI_GUID_DEFINED_SECTION);
         guid = guidDefinedSectionHeader->SectionDefinitionGuid;
         dataOffset = guidDefinedSectionHeader->DataOffset;

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -5053,7 +5053,7 @@ USTATUS FfsParser::parseCpdRegion(const UByteArray & region, const UINT32 localO
         UByteArray partition = region.mid(partitions[i].ptEntry.Offset.Offset, partitions[i].ptEntry.Length);
         while (offset < ((UINT32)partition.size() - sizeof(CPD_EXTENTION_HEADER))) {
             const CPD_EXTENTION_HEADER* extHeader = (const CPD_EXTENTION_HEADER*) (partition.constData() + offset);
-            if (extHeader->Length <= ((UINT32)partition.size() - offset)) {
+            if (extHeader->Length && extHeader->Length <= ((UINT32)partition.size() - offset)) {
                 if (extHeader->Type == CPD_EXT_TYPE_MODULE_ATTRIBUTES) {
                     const CPD_EXT_MODULE_ATTRIBUTES* attrHeader = (const CPD_EXT_MODULE_ATTRIBUTES*)(partition.constData() + offset);
                     length = attrHeader->CompressedSize;

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -1874,7 +1874,11 @@ USTATUS FfsParser::parseVolumeNonUefiData(const UByteArray & data, const UINT32 
     // Sanity check
     if (!index.isValid())
         return U_INVALID_PARAMETER;
-    
+
+    // If parent has the same offset as this item, then we are in infinite recursion, so we break here.
+    if (model->offset(index) == localOffset)
+        return U_INVALID_PARAMETER;
+
     // Get info
     UString info = usprintf("Full size: %Xh (%u)", (UINT32)data.size(), (UINT32)data.size());
     

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -4981,6 +4981,9 @@ USTATUS FfsParser::parseCpdRegion(const UByteArray & region, const UINT32 localO
     std::vector<CPD_PARTITION_INFO> partitions;
     UINT32 offset = ptHeaderSize;
     const CPD_ENTRY* firstCpdEntry = (const CPD_ENTRY*)(body.constData());
+    if(cpdHeader->NumEntries * sizeof(CPD_ENTRY) > (UINT32)body.size()){
+        return U_INVALID_ME_PARTITION_TABLE;
+    }
     for (UINT32 i = 0; i < cpdHeader->NumEntries; i++) {
         // Populate entry header
         const CPD_ENTRY* cpdEntry = firstCpdEntry + i;

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -5327,7 +5327,7 @@ USTATUS FfsParser::parseCpdExtensionsArea(const UModelIndex & index, const UINT3
                 }
             }
             // Parse IFWI Partition Manifest a bit further
-            else if (extHeader->Type == CPD_EXT_TYPE_IFWI_PARTITION_MANIFEST) {
+            else if (extHeader->Type == CPD_EXT_TYPE_IFWI_PARTITION_MANIFEST && partition.size() >= sizeof(CPD_EXT_IFWI_PARTITION_MANIFEST)) {
                 const CPD_EXT_IFWI_PARTITION_MANIFEST* attrHeader = (const CPD_EXT_IFWI_PARTITION_MANIFEST*)partition.constData();
                 
                 // Check HashSize to be sane.

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -5430,6 +5430,8 @@ USTATUS FfsParser::parseSignedPackageInfoData(const UModelIndex & index)
     UByteArray body = model->body(index);
     UINT32 offset = 0;
     while (offset < (UINT32)body.size()) {
+        if(body.size() - offset < sizeof(CPD_EXT_SIGNED_PACKAGE_INFO_MODULE))
+            break;
         const CPD_EXT_SIGNED_PACKAGE_INFO_MODULE* moduleHeader = (const CPD_EXT_SIGNED_PACKAGE_INFO_MODULE*)(body.constData() + offset);
         if ((sizeof(CPD_EXT_SIGNED_PACKAGE_INFO_MODULE) + moduleHeader->HashSize) <= ((UINT32)body.size() - offset)) {
             UByteArray module((const char*)moduleHeader, CpdExtSignedPkgMetadataHashOffset + moduleHeader->HashSize);

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -5040,6 +5040,8 @@ USTATUS FfsParser::parseCpdRegion(const UByteArray & region, const UINT32 localO
         // Parse into data block, find Module Attributes extension, and get compressed size from there
         UINT32 offset = 0;
         UINT32 length = 0xFFFFFFFF; // Special guardian value
+        if(region.size() < partitions[i].ptEntry.Offset.Offset)
+            break;
         UByteArray partition = region.mid(partitions[i].ptEntry.Offset.Offset, partitions[i].ptEntry.Length);
         while (offset < ((UINT32)partition.size() - sizeof(CPD_EXTENTION_HEADER))) {
             const CPD_EXTENTION_HEADER* extHeader = (const CPD_EXTENTION_HEADER*) (partition.constData() + offset);

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -3563,8 +3563,9 @@ USTATUS FfsParser::parseUiSectionBody(const UModelIndex & index)
     // Sanity check
     if (!index.isValid())
         return U_INVALID_PARAMETER;
-    
-    UString text = uFromUcs2(model->body(index).constData());
+
+    const auto body = model->body(index);
+    UString text = uFromUcs2(body.constData(), body.size());
     
     // Add info
     model->addInfo(index, UString("\nText: ") + text);

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -352,7 +352,7 @@ USTATUS FfsParser::parseIntelImage(const UByteArray & intelImage, const UINT32 l
     if (regionSection->MeLimit) {
         me.offset = calculateRegionOffset(regionSection->MeBase);
         me.length = calculateRegionSize(regionSection->MeBase, regionSection->MeLimit);
-        if(me.offset + me.length < me.offset){
+        if (me.offset + me.length < me.offset) {
             return U_INVALID_FLASH_DESCRIPTOR;
         }
         if ((UINT32)intelImage.size() < me.offset + me.length) {
@@ -394,7 +394,8 @@ USTATUS FfsParser::parseIntelImage(const UByteArray & intelImage, const UINT32 l
                 index);
             return U_TRUNCATED_IMAGE;
         }
-        if(intelImage.size() > bios.offset){
+
+        if (intelImage.size() > bios.offset) {
             bios.data = intelImage.mid(bios.offset, bios.length);
             regions.push_back(bios);
         }
@@ -425,7 +426,7 @@ USTATUS FfsParser::parseIntelImage(const UByteArray & intelImage, const UINT32 l
                     return U_TRUNCATED_IMAGE;
                 }
 
-                if(intelImage.size() > region.offset){
+                if (intelImage.size() > region.offset) {
                     region.data = intelImage.mid(region.offset, region.length);
                     regions.push_back(region);
                 }
@@ -2180,9 +2181,11 @@ USTATUS FfsParser::parseFileHeader(const UByteArray & file, const UINT32 localOf
     
     // Get file body
     UByteArray body = file.mid(header.size());
-    if(body.size() < sizeof(UINT16)){
+
+    if (body.size() < sizeof(UINT16)) {
         return U_INVALID_FILE;
     }
+
     // Check for file tail presence
     UByteArray tail;
     bool msgInvalidTailValue = false;
@@ -2792,6 +2795,7 @@ USTATUS FfsParser::parseGuidedSectionHeader(const UByteArray & section, const UI
         dataOffset = guidDefinedSectionHeader->DataOffset;
         attributes = guidDefinedSectionHeader->Attributes;
     }
+
     // Check sanity again
     if ((UINT32)section.size() < headerSize || section.size() < dataOffset)
         return U_INVALID_SECTION;
@@ -4990,9 +4994,11 @@ USTATUS FfsParser::parseCpdRegion(const UByteArray & region, const UINT32 localO
     std::vector<CPD_PARTITION_INFO> partitions;
     UINT32 offset = ptHeaderSize;
     const CPD_ENTRY* firstCpdEntry = (const CPD_ENTRY*)(body.constData());
-    if(cpdHeader->NumEntries * sizeof(CPD_ENTRY) > (UINT32)body.size()){
+
+    if (cpdHeader->NumEntries * sizeof(CPD_ENTRY) > (UINT32)body.size()) {
         return U_INVALID_ME_PARTITION_TABLE;
     }
+
     for (UINT32 i = 0; i < cpdHeader->NumEntries; i++) {
         // Populate entry header
         const CPD_ENTRY* cpdEntry = firstCpdEntry + i;
@@ -5057,8 +5063,11 @@ USTATUS FfsParser::parseCpdRegion(const UByteArray & region, const UINT32 localO
         // Parse into data block, find Module Attributes extension, and get compressed size from there
         UINT32 offset = 0;
         UINT32 length = 0xFFFFFFFF; // Special guardian value
-        if(region.size() <= partitions[i].ptEntry.Offset.Offset)
+
+        if (region.size() <= partitions[i].ptEntry.Offset.Offset) {
             break;
+        }
+
         UByteArray partition = region.mid(partitions[i].ptEntry.Offset.Offset, partitions[i].ptEntry.Length);
         while (offset < ((UINT32)partition.size() - sizeof(CPD_EXTENTION_HEADER))) {
             const CPD_EXTENTION_HEADER* extHeader = (const CPD_EXTENTION_HEADER*) (partition.constData() + offset);
@@ -5315,9 +5324,9 @@ USTATUS FfsParser::parseCpdExtensionsArea(const UModelIndex & index, const UINT3
             if (extHeader->Type == CPD_EXT_TYPE_SIGNED_PACKAGE_INFO) {
                 UByteArray header = partition.left(sizeof(CPD_EXT_SIGNED_PACKAGE_INFO));
                 UByteArray data = partition.mid(header.size());
-                if(header.size() >= sizeof(CPD_EXT_SIGNED_PACKAGE_INFO)){
+                if (header.size() >= sizeof(CPD_EXT_SIGNED_PACKAGE_INFO)) {
                     const CPD_EXT_SIGNED_PACKAGE_INFO* infoHeader = (const CPD_EXT_SIGNED_PACKAGE_INFO*)header.constData();
-                
+
                     info = usprintf("Full size: %Xh (%u)\nHeader size: %Xh (%u)\nBody size: %Xh (%u)\nType: %Xh\n"
                                     "Package name: %.4s\nVersion control number: %Xh\nSecurity version number: %Xh\n"
                                     "Usage bitmap: %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
@@ -5439,7 +5448,7 @@ USTATUS FfsParser::parseSignedPackageInfoData(const UModelIndex & index)
     UByteArray body = model->body(index);
     UINT32 offset = 0;
     while (offset < (UINT32)body.size()) {
-        if(body.size() - offset < sizeof(CPD_EXT_SIGNED_PACKAGE_INFO_MODULE))
+        if (body.size() - offset < sizeof(CPD_EXT_SIGNED_PACKAGE_INFO_MODULE))
             break;
         const CPD_EXT_SIGNED_PACKAGE_INFO_MODULE* moduleHeader = (const CPD_EXT_SIGNED_PACKAGE_INFO_MODULE*)(body.constData() + offset);
         if ((sizeof(CPD_EXT_SIGNED_PACKAGE_INFO_MODULE) + moduleHeader->HashSize) <= ((UINT32)body.size() - offset)) {

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -394,8 +394,10 @@ USTATUS FfsParser::parseIntelImage(const UByteArray & intelImage, const UINT32 l
                 index);
             return U_TRUNCATED_IMAGE;
         }
-        bios.data = intelImage.mid(bios.offset, bios.length);
-        regions.push_back(bios);
+        if(intelImage.size() > bios.offset){
+            bios.data = intelImage.mid(bios.offset, bios.length);
+            regions.push_back(bios);
+        }
     }
     else {
         msg(usprintf("%s: descriptor parsing failed, BIOS region not found in descriptor", __FUNCTION__));

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -5057,7 +5057,7 @@ USTATUS FfsParser::parseCpdRegion(const UByteArray & region, const UINT32 localO
         // Parse into data block, find Module Attributes extension, and get compressed size from there
         UINT32 offset = 0;
         UINT32 length = 0xFFFFFFFF; // Special guardian value
-        if(region.size() < partitions[i].ptEntry.Offset.Offset)
+        if(region.size() <= partitions[i].ptEntry.Offset.Offset)
             break;
         UByteArray partition = region.mid(partitions[i].ptEntry.Offset.Offset, partitions[i].ptEntry.Length);
         while (offset < ((UINT32)partition.size() - sizeof(CPD_EXTENTION_HEADER))) {

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -3695,7 +3695,7 @@ USTATUS FfsParser::parsePeImageSectionBody(const UModelIndex & index, const bool
     }
     
     const EFI_IMAGE_PE_HEADER* peHeader = (EFI_IMAGE_PE_HEADER*)(body.constData() + dosHeader->e_lfanew);
-    if (body.size() < (UINT8*)peHeader - (UINT8*)dosHeader) {
+    if (body.size() < (UINT8*)peHeader - (UINT8*)dosHeader + sizeof(EFI_IMAGE_PE_HEADER)) {
         if (probe)
             return U_INVALID_IMAGE;
         info += UString("\nDOS header: invalid");
@@ -3714,7 +3714,7 @@ USTATUS FfsParser::parsePeImageSectionBody(const UModelIndex & index, const bool
     }
     
     const EFI_IMAGE_FILE_HEADER* imageFileHeader = (const EFI_IMAGE_FILE_HEADER*)(peHeader + 1);
-    if (body.size() < (UINT8*)imageFileHeader - (UINT8*)dosHeader) {
+    if (body.size() < (UINT8*)imageFileHeader - (UINT8*)dosHeader + sizeof(EFI_IMAGE_FILE_HEADER)) {
         if (probe)
             return U_INVALID_IMAGE;
         info += UString("\nPE header: invalid");
@@ -3733,7 +3733,7 @@ USTATUS FfsParser::parsePeImageSectionBody(const UModelIndex & index, const bool
     
     EFI_IMAGE_OPTIONAL_HEADER_POINTERS_UNION optionalHeader = {};
     optionalHeader.H32 = (const EFI_IMAGE_OPTIONAL_HEADER32*)(imageFileHeader + 1);
-    if (body.size() < (UINT8*)optionalHeader.H32 - (UINT8*)dosHeader) {
+    if (body.size() < (UINT8*)optionalHeader.H32 - (UINT8*)dosHeader + sizeof(EFI_IMAGE_OPTIONAL_HEADER32)) {
         if (probe)
             return U_INVALID_IMAGE;
         info += UString("\nPE optional header: invalid");

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -2983,7 +2983,7 @@ USTATUS FfsParser::parseGuidedSectionHeader(const UByteArray & section, const UI
 USTATUS FfsParser::parseFreeformGuidedSectionHeader(const UByteArray & section, const UINT32 localOffset, const UModelIndex & parent, UModelIndex & index, const bool probe)
 {
     // Check sanity
-    if ((UINT32)section.size() < sizeof(EFI_COMMON_SECTION_HEADER))
+    if ((UINT32)section.size() < sizeof(EFI_COMMON_SECTION_HEADER) + sizeof(EFI_FREEFORM_SUBTYPE_GUID_SECTION))
         return U_INVALID_SECTION;
     
     // Obtain required information from parent volume

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -352,6 +352,9 @@ USTATUS FfsParser::parseIntelImage(const UByteArray & intelImage, const UINT32 l
     if (regionSection->MeLimit) {
         me.offset = calculateRegionOffset(regionSection->MeBase);
         me.length = calculateRegionSize(regionSection->MeBase, regionSection->MeLimit);
+        if(me.offset + me.length < me.offset){
+            return U_INVALID_FLASH_DESCRIPTOR;
+        }
         if ((UINT32)intelImage.size() < me.offset + me.length) {
             msg(usprintf("%s: ", __FUNCTION__)
                 + itemSubtypeToUString(Types::Region, me.type)

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -5041,7 +5041,7 @@ USTATUS FfsParser::parseCpdRegion(const UByteArray & region, const UINT32 localO
         UINT32 offset = 0;
         UINT32 length = 0xFFFFFFFF; // Special guardian value
         UByteArray partition = region.mid(partitions[i].ptEntry.Offset.Offset, partitions[i].ptEntry.Length);
-        while (offset < (UINT32)partition.size()) {
+        while (offset < ((UINT32)partition.size() - sizeof(CPD_EXTENTION_HEADER))) {
             const CPD_EXTENTION_HEADER* extHeader = (const CPD_EXTENTION_HEADER*) (partition.constData() + offset);
             if (extHeader->Length <= ((UINT32)partition.size() - offset)) {
                 if (extHeader->Type == CPD_EXT_TYPE_MODULE_ATTRIBUTES) {
@@ -5282,7 +5282,7 @@ USTATUS FfsParser::parseCpdExtensionsArea(const UModelIndex & index, const UINT3
     
     UByteArray body = model->body(index);
     UINT32 offset = 0;
-    while (offset < (UINT32)body.size()) {
+    while (offset < (UINT32)body.size() - sizeof(CPD_EXTENTION_HEADER)) {
         const CPD_EXTENTION_HEADER* extHeader = (const CPD_EXTENTION_HEADER*) (body.constData() + offset);
         if (extHeader->Length > 0
             && extHeader->Length <= ((UINT32)body.size() - offset)) {

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -5417,8 +5417,7 @@ USTATUS FfsParser::parseSignedPackageInfoData(const UModelIndex & index)
     UINT32 offset = 0;
     while (offset < (UINT32)body.size()) {
         const CPD_EXT_SIGNED_PACKAGE_INFO_MODULE* moduleHeader = (const CPD_EXT_SIGNED_PACKAGE_INFO_MODULE*)(body.constData() + offset);
-        if (sizeof(CPD_EXT_SIGNED_PACKAGE_INFO_MODULE) <= ((UINT32)body.size() - offset)) {
-            // TODO: check sanity of moduleHeader->HashSize
+        if ((sizeof(CPD_EXT_SIGNED_PACKAGE_INFO_MODULE) + moduleHeader->HashSize) <= ((UINT32)body.size() - offset)) {
             UByteArray module((const char*)moduleHeader, CpdExtSignedPkgMetadataHashOffset + moduleHeader->HashSize);
             UString name = usprintf("%.12s", moduleHeader->Name);
             

--- a/common/ffsparser.cpp
+++ b/common/ffsparser.cpp
@@ -5372,10 +5372,10 @@ USTATUS FfsParser::parseCpdExtensionsArea(const UModelIndex & index, const UINT3
                 }
             }
             // Parse Module Attributes a bit further
-            else if (extHeader->Type == CPD_EXT_TYPE_MODULE_ATTRIBUTES) {
+            else if (extHeader->Type == CPD_EXT_TYPE_MODULE_ATTRIBUTES && partition.size() >= sizeof(CPD_EXT_MODULE_ATTRIBUTES)) {
                 const CPD_EXT_MODULE_ATTRIBUTES* attrHeader = (const CPD_EXT_MODULE_ATTRIBUTES*)partition.constData();
                 int hashSize = (UINT32)partition.size() - CpdExtModuleImageHashOffset;
-                
+
                 // This hash is stored reversed
                 // Need to reverse it back to normal
                 UByteArray hash((const char*)attrHeader + CpdExtModuleImageHashOffset, hashSize);

--- a/common/fitparser.cpp
+++ b/common/fitparser.cpp
@@ -227,7 +227,7 @@ void FitParser::findFitRecursive(const UModelIndex & index, UModelIndex & found,
     UINT64 fitSignatureValue = INTEL_FIT_SIGNATURE;
     UByteArray fitSignature((const char*)&fitSignatureValue, sizeof(fitSignatureValue));
 
-    if(lastVtfBody.size() < INTEL_FIT_POINTER_OFFSET)
+    if (lastVtfBody.size() < INTEL_FIT_POINTER_OFFSET)
         return;
 
     UINT32 storedFitAddress = *(const UINT32*)(lastVtfBody.constData() + lastVtfBody.size() - INTEL_FIT_POINTER_OFFSET);

--- a/common/fitparser.cpp
+++ b/common/fitparser.cpp
@@ -221,6 +221,10 @@ void FitParser::findFitRecursive(const UModelIndex & index, UModelIndex & found,
     UByteArray lastVtfBody = model->body(ffsParser->lastVtf);
     UINT64 fitSignatureValue = INTEL_FIT_SIGNATURE;
     UByteArray fitSignature((const char*)&fitSignatureValue, sizeof(fitSignatureValue));
+
+    if(lastVtfBody.size() < INTEL_FIT_POINTER_OFFSET)
+        return;
+
     UINT32 storedFitAddress = *(const UINT32*)(lastVtfBody.constData() + lastVtfBody.size() - INTEL_FIT_POINTER_OFFSET);
     for (INT32 offset = (INT32)model->body(index).indexOf(fitSignature);
          offset >= 0;

--- a/common/fitparser.cpp
+++ b/common/fitparser.cpp
@@ -70,7 +70,12 @@ USTATUS FitParser::parseFit(const UModelIndex & index)
         msg(usprintf("%s: not enough space to contain the whole FIT table", __FUNCTION__), fitIndex);
         return U_INVALID_FIT;
     }
-    
+
+    if (fitSize == 0) {
+        msg(usprintf("%s: FIT header size is 0", __FUNCTION__));
+        return U_INVALID_FIT;
+    }
+
     // Check FIT checksum, if present
     if (fitHeader->ChecksumValid) {
         // Calculate FIT entry checksum

--- a/common/kaitai/kaitaistream.cpp
+++ b/common/kaitai/kaitaistream.cpp
@@ -478,13 +478,24 @@ uint64_t kaitai::kstream::read_bits_int_le(int n) {
 // ========================================================================
 
 std::string kaitai::kstream::read_bytes(std::streamsize len) {
-    std::vector<char> result(len);
-
     // NOTE: streamsize type is signed, negative values are only *supposed* to not be used.
     // https://en.cppreference.com/w/cpp/io/streamsize
     if (len < 0) {
         throw std::runtime_error("read_bytes: requested a negative amount");
     }
+
+    if (len > 0) {
+        // Check that the stream has enough data before allocating
+        std::streampos cur_pos = m_io->tellg();
+        m_io->seekg(0, std::ios::end);
+        std::streampos end_pos = m_io->tellg();
+        m_io->seekg(cur_pos);
+        if (len > end_pos - cur_pos) {
+            throw std::runtime_error("read_bytes: requested more bytes than available in stream");
+        }
+    }
+
+    std::vector<char> result(len);
 
     if (len > 0) {
         m_io->read(&result[0], len);

--- a/common/meparser.cpp
+++ b/common/meparser.cpp
@@ -600,7 +600,8 @@ make_partition_table_consistent:
         UINT32 previousPartitionEnd = partitions[i - 1].ptEntry.Offset + partitions[i - 1].ptEntry.Size;
         
         // Check that current region is fully present in the image
-        if ((UINT32)partitions[i].ptEntry.Offset + (UINT32)partitions[i].ptEntry.Size > (UINT32)region.size()) {
+        if (partitions[i].ptEntry.Offset > UINT_MAX - partitions[i].ptEntry.Size ||
+            (UINT32)partitions[i].ptEntry.Offset + (UINT32)partitions[i].ptEntry.Size > (UINT32)region.size()) {
             if ((UINT32)partitions[i].ptEntry.Offset >= (UINT32)region.size()) {
                 msg(usprintf("%s: IFWI partition is located outside of the opened image, skipped", __FUNCTION__), index);
                 partitions.erase(partitions.begin() + i);

--- a/common/meparser.cpp
+++ b/common/meparser.cpp
@@ -184,7 +184,7 @@ USTATUS MeParser::parseFptRegion(const UByteArray & region, const UModelIndex & 
     UINT32 numEntries = ptHeader->NumEntries;
     const FPT_HEADER_ENTRY* firstPtEntry = (const FPT_HEADER_ENTRY*)(region.constData() + offset);
 
-    if ((UINT32)offset + sizeof(const FPT_HEADER_ENTRY*) * numEntries > region.size()) {
+    if ((UINT32)offset + sizeof(FPT_HEADER_ENTRY) * numEntries >= region.size()) {
         msg(usprintf("%s: Corrupted ME region, too many header entries", __FUNCTION__), parent);
         return U_INVALID_ME_PARTITION_TABLE;
     }
@@ -467,7 +467,7 @@ make_partition_table_consistent:
     // Partition map is consistent
     for (size_t i = 0; i < partitions.size(); i++) {
         // Sanity check
-        if (partitions[i].ptEntry.Offset > region.size())
+        if (partitions[i].ptEntry.Offset >= region.size())
             break;
         UByteArray partition = region.mid(partitions[i].ptEntry.Offset, partitions[i].ptEntry.Size);
         if (partitions[i].type == Types::IfwiPartition) {

--- a/common/meparser.cpp
+++ b/common/meparser.cpp
@@ -249,9 +249,9 @@ make_partition_table_consistent:
     // Check for intersections/paddings between partitions
     for (size_t i = 1; i < partitions.size(); i++) {
         UINT32 previousPartitionEnd = partitions[i - 1].ptEntry.Offset + partitions[i - 1].ptEntry.Size;
-        
         // Check that current region is fully present in the image
-        if ((UINT32)partitions[i].ptEntry.Offset + (UINT32)partitions[i].ptEntry.Size > (UINT32)region.size()) {
+        if (partitions[i].ptEntry.Offset > UINT_MAX - partitions[i].ptEntry.Size ||
+            (UINT32)partitions[i].ptEntry.Offset + (UINT32)partitions[i].ptEntry.Size > (UINT32)region.size()) {
             if ((UINT32)partitions[i].ptEntry.Offset >= (UINT32)region.size()) {
                 msg(usprintf("%s: FPT partition is located outside of the opened image, skipped", __FUNCTION__), partitions[i].index);
                 partitions.erase(partitions.begin() + i);

--- a/common/meparser.cpp
+++ b/common/meparser.cpp
@@ -460,6 +460,9 @@ make_partition_table_consistent:
     
     // Partition map is consistent
     for (size_t i = 0; i < partitions.size(); i++) {
+        // Sanity check
+        if (partitions[i].ptEntry.Offset > region.size())
+            break;
         UByteArray partition = region.mid(partitions[i].ptEntry.Offset, partitions[i].ptEntry.Size);
         if (partitions[i].type == Types::IfwiPartition) {
             UModelIndex partitionIndex;

--- a/common/meparser.cpp
+++ b/common/meparser.cpp
@@ -183,6 +183,12 @@ USTATUS MeParser::parseFptRegion(const UByteArray & region, const UModelIndex & 
     UINT32 offset = (UINT32)header.size();
     UINT32 numEntries = ptHeader->NumEntries;
     const FPT_HEADER_ENTRY* firstPtEntry = (const FPT_HEADER_ENTRY*)(region.constData() + offset);
+
+    if ((UINT32)offset + sizeof(const FPT_HEADER_ENTRY*) * numEntries > region.size()) {
+        msg(usprintf("%s: Corrupted ME region, too many header entries", __FUNCTION__), parent);
+        return U_INVALID_ME_PARTITION_TABLE;
+    }
+
     for (UINT32 i = 0; i < numEntries; i++) {
         // Populate entry header
         const FPT_HEADER_ENTRY* ptEntry = firstPtEntry + i;

--- a/common/nvramparser.cpp
+++ b/common/nvramparser.cpp
@@ -205,6 +205,10 @@ USTATUS NvramParser::parseNvarStore(const UModelIndex & index, const bool probe)
                 if (guidsInStore < entry_body->guid_index() + 1)
                     guidsInStore = entry_body->guid_index() + 1;
 
+                // Sanity check.
+                if(nvar.size() < sizeof(EFI_GUID) * (entry_body->guid_index() + 1))
+                   goto processing_done;
+
                 // The list begins at the end of the store and goes backwards
                 const EFI_GUID g = readUnaligned((EFI_GUID*)(nvar.constData() + nvar.size()) - (entry_body->guid_index() + 1));
                 name = guidToUString(g);

--- a/common/nvramparser.cpp
+++ b/common/nvramparser.cpp
@@ -56,8 +56,10 @@ USTATUS NvramParser::parseNvarStore(const UModelIndex & index, const bool probe)
     UINT8 emptyByte = 0xFF;
     if (model->hasEmptyParsingData(index) == false) {
         UByteArray data = model->parsingData(index);
-        const VOLUME_PARSING_DATA* pdata = (const VOLUME_PARSING_DATA*)data.constData();
-        emptyByte = pdata->emptyByte;
+        if ((UINT32)data.size() >= sizeof(VOLUME_PARSING_DATA)) {
+            const VOLUME_PARSING_DATA* pdata = (const VOLUME_PARSING_DATA*)data.constData();
+            emptyByte = pdata->emptyByte;
+        }
     }
     
     try {
@@ -320,8 +322,10 @@ USTATUS NvramParser::parseNvramVolumeBody(const UModelIndex & index,const UINT32
     UINT8 emptyByte = 0xFF;
     if (model->hasEmptyParsingData(index) == false) {
         UByteArray data = model->parsingData(index);
-        const VOLUME_PARSING_DATA* pdata = (const VOLUME_PARSING_DATA*)data.constData();
-        emptyByte = pdata->emptyByte;
+        if ((UINT32)data.size() >= sizeof(VOLUME_PARSING_DATA)) {
+            const VOLUME_PARSING_DATA* pdata = (const VOLUME_PARSING_DATA*)data.constData();
+            emptyByte = pdata->emptyByte;
+        }
     }
     
     // Get local offset

--- a/common/nvramparser.cpp
+++ b/common/nvramparser.cpp
@@ -208,7 +208,7 @@ USTATUS NvramParser::parseNvarStore(const UModelIndex & index, const bool probe)
                     guidsInStore = entry_body->guid_index() + 1;
 
                 // Sanity check.
-                if(nvar.size() < sizeof(EFI_GUID) * (entry_body->guid_index() + 1))
+                if (nvar.size() < sizeof(EFI_GUID) * (entry_body->guid_index() + 1))
                    goto processing_done;
 
                 // The list begins at the end of the store and goes backwards

--- a/common/ustring.cpp
+++ b/common/ustring.cpp
@@ -112,11 +112,11 @@ UString uFromUcs2(const char* str, size_t max_len)
     // Naive implementation assuming that only ASCII LE part of UCS2 is used, str may not be aligned.
     UString msg;
     const char *str8 = str;
-    size_t rest = (max_len == 0) ? SIZE_MAX : max_len;
-    while (str8[0] && rest) {
+    size_t rest = (max_len == 0) ? SIZE_MAX : max_len - (max_len % 2);
+    while (rest > 0 && str8[0]) {
         msg += str8[0];
         str8 += 2;
-        rest--;
+        rest -= 2;
     }
     return msg;
 }

--- a/common/utility.cpp
+++ b/common/utility.cpp
@@ -206,7 +206,11 @@ USTATUS decompress(const UByteArray & compressedData, const UINT8 compressionTyp
     UINT8* scratch;
     UINT32 scratchSize = 0;
     const EFI_TIANO_HEADER* header;
-    
+
+    if(compressedData.size() == 0){
+        return U_BUFFER_TOO_SMALL;
+    }
+
     // For all but LZMA dictionary size is 0
     dictionarySize = 0;
     

--- a/common/utility.cpp
+++ b/common/utility.cpp
@@ -238,7 +238,8 @@ USTATUS decompress(const UByteArray & compressedData, const UINT8 compressionTyp
             if (U_SUCCESS != EfiTianoGetInfo(data, dataSize, &decompressedSize, &scratchSize))
                 return U_STANDARD_DECOMPRESSION_FAILED;
 
-            if (decompressedSize > INT32_MAX)
+            // Check for suspiciously large decompressed size
+            if (decompressedSize > INT32_MAX / 4)
                 return U_STANDARD_DECOMPRESSION_FAILED;
 
             // Allocate memory
@@ -251,14 +252,13 @@ USTATUS decompress(const UByteArray & compressedData, const UINT8 compressionTyp
                 free(scratch);
                 return U_STANDARD_DECOMPRESSION_FAILED;
             }
-            
+
             // Decompress section data using both algorithms
             USTATUS result = U_SUCCESS;
             // Try Tiano
             USTATUS TianoResult = TianoDecompress(data, dataSize, decompressed, decompressedSize, scratch, scratchSize);
             // Try EFI 1.1
             USTATUS EfiResult = EfiDecompress(data, dataSize, efiDecompressed, decompressedSize, scratch, scratchSize);
-            
             if (EfiResult == U_SUCCESS && TianoResult == U_SUCCESS) { // Both decompressions are OK
                 algorithm = COMPRESSION_ALGORITHM_UNDECIDED;
                 decompressedData = UByteArray((const char*)decompressed, (int)decompressedSize);

--- a/common/utility.cpp
+++ b/common/utility.cpp
@@ -237,7 +237,10 @@ USTATUS decompress(const UByteArray & compressedData, const UINT8 compressionTyp
             // Get info function is the same for both algorithms
             if (U_SUCCESS != EfiTianoGetInfo(data, dataSize, &decompressedSize, &scratchSize))
                 return U_STANDARD_DECOMPRESSION_FAILED;
-            
+
+            if (decompressedSize > INT32_MAX)
+                return U_STANDARD_DECOMPRESSION_FAILED;
+
             // Allocate memory
             decompressed = (UINT8*)malloc(decompressedSize);
             efiDecompressed = (UINT8*)malloc(decompressedSize);
@@ -256,10 +259,7 @@ USTATUS decompress(const UByteArray & compressedData, const UINT8 compressionTyp
             // Try EFI 1.1
             USTATUS EfiResult = EfiDecompress(data, dataSize, efiDecompressed, decompressedSize, scratch, scratchSize);
             
-            if (decompressedSize > INT32_MAX) {
-                result = U_STANDARD_DECOMPRESSION_FAILED;
-            }
-            else if (EfiResult == U_SUCCESS && TianoResult == U_SUCCESS) { // Both decompressions are OK
+            if (EfiResult == U_SUCCESS && TianoResult == U_SUCCESS) { // Both decompressions are OK
                 algorithm = COMPRESSION_ALGORITHM_UNDECIDED;
                 decompressedData = UByteArray((const char*)decompressed, (int)decompressedSize);
                 efiDecompressedData = UByteArray((const char*)efiDecompressed, (int)decompressedSize);

--- a/common/utility.cpp
+++ b/common/utility.cpp
@@ -289,6 +289,7 @@ USTATUS decompress(const UByteArray & compressedData, const UINT8 compressionTyp
             if (U_SUCCESS != LzmaGetInfo(data, dataSize, &decompressedSize)) {
                 // Get info as Intel legacy LZMA section
                 data += sizeof(UINT32);
+                dataSize -= sizeof(UINT32);
                 if (U_SUCCESS != LzmaGetInfo(data, dataSize, &decompressedSize)) {
                     return U_CUSTOMIZED_DECOMPRESSION_FAILED;
                 }

--- a/common/utility.cpp
+++ b/common/utility.cpp
@@ -207,7 +207,7 @@ USTATUS decompress(const UByteArray & compressedData, const UINT8 compressionTyp
     UINT32 scratchSize = 0;
     const EFI_TIANO_HEADER* header;
 
-    if(compressedData.size() == 0){
+    if(compressedData.size() < 4){
         return U_BUFFER_TOO_SMALL;
     }
 

--- a/common/utility.cpp
+++ b/common/utility.cpp
@@ -207,7 +207,7 @@ USTATUS decompress(const UByteArray & compressedData, const UINT8 compressionTyp
     UINT32 scratchSize = 0;
     const EFI_TIANO_HEADER* header;
 
-    if(compressedData.size() < 4){
+    if (compressedData.size() < 4) {
         return U_BUFFER_TOO_SMALL;
     }
 

--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -3,7 +3,14 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.22)
 PROJECT(ffsparser_fuzzer LANGUAGES C CXX)
 
 OPTION(USE_QT "Link against Qt" OFF)
-OPTION(USE_AFL "Build in AFL-compatible mode" OFF)
+
+if (CMAKE_CXX_COMPILER MATCHES "afl-")
+  MESSAGE("-- Building in AFL-compatible mode")
+  SET(USE_AFL ON)
+ELSE()
+  MESSAGE("-- Building in libFuzzer mode")
+  SET(USE_AFL OFF)
+ENDIF()
 
 SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -82,12 +89,6 @@ SET(PROJECT_SOURCES
  ../common/zlib/zutil.c
 )
 
-IF(USE_AFL)
-  SET(PROJECT_SOURCES ${PROJECT_SOURCES} afl_driver.cpp)
-  MESSAGE("-- Building in AFL-compatible mode")
-ELSE()
-  MESSAGE("-- Building in libFuzzer mode")
-ENDIF()
 
 IF(NOT USE_QT)
   SET(PROJECT_SOURCES ${PROJECT_SOURCES}
@@ -110,12 +111,12 @@ ADD_DEFINITIONS(
 ADD_EXECUTABLE(ffsparser_fuzzer ${PROJECT_SOURCES})
 
 
-IF(NOT USE_AFL_DRIVER)
+IF(USE_AFL)
+TARGET_COMPILE_OPTIONS(ffsparser_fuzzer PRIVATE -O1 -fno-omit-frame-pointer -g -ggdb3 -fsanitize=fuzzer)
+TARGET_LINK_LIBRARIES(ffsparser_fuzzer PRIVATE -fsanitize=fuzzer)
+ELSE()
 TARGET_COMPILE_OPTIONS(ffsparser_fuzzer PRIVATE -O1 -fno-omit-frame-pointer -g -ggdb3 -fsanitize=fuzzer,address,undefined -fsanitize-address-use-after-scope -fno-sanitize-recover=undefined)
 TARGET_LINK_LIBRARIES(ffsparser_fuzzer PRIVATE -fsanitize=fuzzer,address,undefined)
-ELSE()
-TARGET_COMPILE_OPTIONS(ffsparser_fuzzer PRIVATE -O1 -fno-omit-frame-pointer -g -ggdb3 -fsanitize=address,undefined -fsanitize-coverage=trace-pc-guard -fsanitize-address-use-after-scope -fno-sanitize-recover=undefined)
-TARGET_LINK_LIBRARIES(ffsparser_fuzzer PRIVATE -fsanitize=address,undefined)
 ENDIF()
 
 IF(USE_QT)

--- a/fuzzing/afl_driver.cpp
+++ b/fuzzing/afl_driver.cpp
@@ -48,6 +48,7 @@ If 1, close stdout at startup. If 2 close stderr; if 3 close both.
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdarg.h>
 
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
This PR contains a set of patches resulting from fuzzing UEFITool. Each commit includes the corresponding crash report (mostly ASAN traces) together with a reference to the crashing input, which are attached.

Based on our testing, these changes do not break any existing functionality. Running the tool against a few hundred firmware images produces identical results with and without this PR. Moreover, the patches improve robustness by enabling successful parsing of additional real-world firmware images. For example, [this HPE firmware](https://downloads.hpe.com/pub/softlib2/software1/sc-windows-uefi-sys/p145084115/v120817/cp030447.exe) sample currently triggers a `std::out_of_range exception`, whereas with this PR it is parsed successfully.

This is joint work with @yeggor, so kudos to him too!

[crashing-inputs.zip](https://github.com/user-attachments/files/25398536/crashing-inputs.zip)
