### PR TITLE
Allow searching through information section

### DIFF
--- a/UEFITool/ffsfinder.cpp
+++ b/UEFITool/ffsfinder.cpp
@@ -233,6 +233,25 @@ USTATUS FfsFinder::findTextPattern(const UModelIndex & index, const UString & pa
             ret = U_SUCCESS;
     }
 
+    if (mode == SEARCH_MODE_INFO || mode == SEARCH_MODE_ALL) {
+        UString info = model->info(index);
+        if (!info.isEmpty() && info.indexOf(pattern, 0, caseSensitive) >= 0) {
+            UModelIndex parentFileIndex = model->findParentOfType(index, Types::File);
+            UString name = model->name(index);
+            if (model->parent(index) == parentFileIndex) {
+                name = model->name(parentFileIndex) + UString("/") + name;
+            }
+            else if (parentFileIndex.isValid()) {
+                name = model->name(parentFileIndex) + UString("/.../") + name;
+            }
+
+            msg(UString("Text \"") + UString(pattern) + UString("\" found in ") + name + UString(" information"), index);
+            ret = U_SUCCESS;
+        }
+        if (mode == SEARCH_MODE_INFO)
+            return ret;
+    }
+
     UByteArray body;
     if (hasChildren) {
         if (mode != SEARCH_MODE_BODY)

--- a/UEFITool/searchdialog.ui
+++ b/UEFITool/searchdialog.ui
@@ -179,7 +179,7 @@
           <item>
            <widget class="QRadioButton" name="textScopeFullRadioButton">
             <property name="text">
-             <string>Header and body</string>
+             <string>Header, body and information</string>
             </property>
             <property name="checked">
              <bool>true</bool>
@@ -197,6 +197,13 @@
            <widget class="QRadioButton" name="textScopeBodyRadioButton">
             <property name="text">
              <string>Body only</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="textScopeInfoRadioButton">
+            <property name="text">
+             <string>Information only</string>
             </property>
            </widget>
           </item>

--- a/UEFITool/uefitool.cpp
+++ b/UEFITool/uefitool.cpp
@@ -468,9 +468,10 @@ void UEFITool::search()
     searchDialog->ui->guidScopeBodyRadioButton->setChecked(mode == SEARCH_MODE_BODY);
     searchDialog->ui->guidScopeFullRadioButton->setChecked(mode >= SEARCH_MODE_ALL);
     mode = settings.value("searchDialog/textScopeMode", SEARCH_MODE_ALL).toUInt();
-    searchDialog->ui->textScopeHeaderRadioButton->setChecked(mode <= SEARCH_MODE_HEADER);
+    searchDialog->ui->textScopeHeaderRadioButton->setChecked(mode == SEARCH_MODE_HEADER);
     searchDialog->ui->textScopeBodyRadioButton->setChecked(mode == SEARCH_MODE_BODY);
-    searchDialog->ui->textScopeFullRadioButton->setChecked(mode >= SEARCH_MODE_ALL);
+    searchDialog->ui->textScopeFullRadioButton->setChecked(mode == SEARCH_MODE_ALL);
+    searchDialog->ui->textScopeInfoRadioButton->setChecked(mode == SEARCH_MODE_INFO);
     searchDialog->ui->textUnicodeCheckBox->setChecked(settings.value("searchDialog/textUnicode", true).toBool());
     searchDialog->ui->textCaseSensitiveCheckBox->setChecked(settings.value("searchDialog/textCaseSensitive", false).toBool());
 
@@ -497,6 +498,8 @@ void UEFITool::search()
         mode = SEARCH_MODE_HEADER;
     else if (searchDialog->ui->textScopeBodyRadioButton->isChecked())
         mode = SEARCH_MODE_BODY;
+    else if (searchDialog->ui->textScopeInfoRadioButton->isChecked())
+        mode = SEARCH_MODE_INFO;
     else
         mode = SEARCH_MODE_ALL;
     settings.setValue("searchDialog/textScopeMode", mode);
@@ -545,6 +548,8 @@ void UEFITool::search()
             mode = SEARCH_MODE_HEADER;
         else if (searchDialog->ui->textScopeBodyRadioButton->isChecked())
             mode = SEARCH_MODE_BODY;
+        else if (searchDialog->ui->textScopeInfoRadioButton->isChecked())
+            mode = SEARCH_MODE_INFO;
         else
             mode = SEARCH_MODE_ALL;
         ffsFinder->findTextPattern(pattern, mode, searchDialog->ui->textUnicodeCheckBox->isChecked(),

--- a/common/basetypes.h
+++ b/common/basetypes.h
@@ -172,6 +172,7 @@ typedef ptrdiff_t INTN;
 #define SEARCH_MODE_HEADER    1
 #define SEARCH_MODE_BODY      2
 #define SEARCH_MODE_ALL       3
+#define SEARCH_MODE_INFO      4
 
 // EFI GUID
 typedef struct EFI_GUID_ {


### PR DESCRIPTION
Searching for decoded keywords is really useful, for example searching for depex entries like EfiSmmBase2ProtocolGuid